### PR TITLE
Noise gen plus multiple oscillators

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,11 @@ To run examples, you should also do:
 ```
 pip install ipython librosa matplotlib
 ```
+
+Unfortunately, Python 3.9 (e.g. OSX Big Sur) won't work, because
+librosa repends upon numba which isn't packaged for 3.9 yet. In
+which case you'll have to create a Python 3.7 conda environment.
+(You might also need to downgrade LLVM to 10 or 9.):
+```
+conda install -c conda-forge ipython librosa matplotlib numpy matplotlib scipy jupytext
+```

--- a/examples/examples.py
+++ b/examples/examples.py
@@ -112,6 +112,22 @@ stft_plot(drum_out)
 
 ipd.Audio(drum_out, rate=vca.sample_rate)
 # -
+# Use the `noise_ratio` parameter to add noise.
+
+# +
+my_drum = Drum(
+    pitch_adsr=ADSR(0.25, 0.25, 0.25, 0.25, alpha=3),
+    amp_adsr=ADSR(0.25, 0.25, 0.25, 0.25),
+    vco=SineVCO(midi_f0=55, mod_depth=6),
+    sustain_duration=1,
+    noise_ratio=0.5
+)
+
+drum_out = my_drum()
+stft_plot(drum_out)
+ipd.Audio(drum_out, rate=vca.sample_rate)
+# -
+
 # You can also use the **SquareSawVCO oscillator** in the drum module.
 
 
@@ -121,6 +137,24 @@ my_drum = Drum(
     amp_adsr=ADSR(0.25, 0.25, 0.25, 0.25),
     vco=SquareSawVCO(shape=0, midi_f0=24, mod_depth=12),
     sustain_duration=1,
+)
+
+drum_out = my_drum()
+stft_plot(drum_out)
+ipd.Audio(drum_out, rate=vca.sample_rate)
+# -
+
+# Additionally, the Drum class can take any number of oscillators.
+
+# +
+my_drum = Drum(
+    pitch_adsr=ADSR(0.25, 0.25, 0.25, 0.25, alpha=3),
+    amp_adsr=ADSR(0.25, 0.25, 0.25, 0.25),
+    vco=[
+        SquareSawVCO(shape=0, midi_f0=23.95, mod_depth=12),
+        SquareSawVCO(shape=0, midi_f0=24.05, mod_depth=12)
+    ],
+    sustain_duration=1
 )
 
 drum_out = my_drum()

--- a/examples/examples.py
+++ b/examples/examples.py
@@ -97,7 +97,7 @@ noisey_out = noiser(sqs_out)
 
 time_plot(noisey_out)
 stft_plot(noisey_out)
-ipd.Audio(noisey_out, rate=vca.sample_rate)
+ipd.Audio(noisey_out, rate=sqs.sample_rate)
 
 # Notice that this sound is rather clicky. We'll add an envelope to the amplitude to smooth it out.
 

--- a/examples/examples.py
+++ b/examples/examples.py
@@ -15,8 +15,8 @@ import librosa.display
 import matplotlib.pyplot as plt
 import numpy as np
 
-from ddspdrum.module import ADSR, VCA, Drum, SineVCO, SquareSawVCO, NoiseModule
 from ddspdrum.defaults import SAMPLE_RATE
+from ddspdrum.module import ADSR, VCA, Drum, NoiseModule, SineVCO, SquareSawVCO
 
 # -
 
@@ -132,11 +132,11 @@ ipd.Audio(drum_out, rate=vca.sample_rate)
 my_drum = Drum(
     pitch_adsr=ADSR(0.25, 0.25, 0.25, 0.25, alpha=3),
     amp_adsr=ADSR(0.25, 0.25, 0.25, 0.25),
-    vco_1 = SquareSawVCO(shape=0, midi_f0=23.95, mod_depth=12),
-    vco_2 = SquareSawVCO(shape=0, midi_f0=24.05, mod_depth=12),
-    vco_1_ratio = 0.5,
-    noise_module = NoiseModule(ratio=0.1),
-    sustain_duration=1
+    vco_1=SquareSawVCO(shape=0, midi_f0=23.95, mod_depth=12),
+    vco_2=SquareSawVCO(shape=0, midi_f0=24.05, mod_depth=12),
+    vco_1_ratio=0.5,
+    noise_module=NoiseModule(ratio=0.1),
+    sustain_duration=1,
 )
 
 drum_out = my_drum()
@@ -150,7 +150,14 @@ ipd.Audio(drum_out, rate=vca.sample_rate)
 # response (FIR) lowpasses and an infinite impulse response (IIR)
 # state variable filter.
 
-from ddspdrum.module import FIR, MovingAverage, LowPassSVF, HighPassSVF, BandPassSVF, BandRejectSVF
+from ddspdrum.module import (
+    FIR,
+    BandPassSVF,
+    BandRejectSVF,
+    HighPassSVF,
+    LowPassSVF,
+    MovingAverage,
+)
 
 # Create some white noise to perform filtering on -- **Watch out it is loud!**
 

--- a/examples/examples.py
+++ b/examples/examples.py
@@ -15,7 +15,7 @@ import librosa.display
 import matplotlib.pyplot as plt
 import numpy as np
 
-from ddspdrum.module import ADSR, VCA, Drum, SineVCO, SquareSawVCO
+from ddspdrum.module import ADSR, VCA, Drum, SineVCO, SquareSawVCO, NoiseModule, Mixer
 from ddspdrum.defaults import SAMPLE_RATE
 
 # -
@@ -86,11 +86,24 @@ sqs_out = sqs(envelope, phase=0)
 stft_plot(sqs_out)
 ipd.Audio(sqs_out, rate=sqs.sample_rate)
 
+# Add noise with the NoiseModule class.
+
+# +
+# NoiseModule test.
+
+noiser = NoiseModule(ratio=0.5)
+noisey_out = noiser(sqs_out)
+# -
+
+time_plot(noisey_out)
+stft_plot(noisey_out)
+ipd.Audio(noisey_out, rate=vca.sample_rate)
+
 # Notice that this sound is rather clicky. We'll add an envelope to the amplitude to smooth it out.
 
 # VCA test
 vca = VCA()
-vca_out = vca(envelope, sqs_out)
+vca_out = vca(envelope, noisey_out)
 
 time_plot(vca_out)
 stft_plot(vca_out)
@@ -102,7 +115,8 @@ ipd.Audio(vca_out, rate=vca.sample_rate)
 my_drum = Drum(
     pitch_adsr=ADSR(0.25, 0.25, 0.25, 0.25, alpha=3),
     amp_adsr=ADSR(0.25, 0.25, 0.25, 0.25),
-    vco=SineVCO(midi_f0=69, mod_depth=12),
+    vco_1=SineVCO(midi_f0=69, mod_depth=12),
+    noise_module=NoiseModule(ratio=0.5),
     sustain_duration=1,
 )
 
@@ -112,48 +126,16 @@ stft_plot(drum_out)
 
 ipd.Audio(drum_out, rate=vca.sample_rate)
 # -
-# Use the `noise_ratio` parameter to add noise.
+# Additionally, the Drum class can take two oscillators.
 
 # +
 my_drum = Drum(
     pitch_adsr=ADSR(0.25, 0.25, 0.25, 0.25, alpha=3),
     amp_adsr=ADSR(0.25, 0.25, 0.25, 0.25),
-    vco=SineVCO(midi_f0=55, mod_depth=6),
-    sustain_duration=1,
-    noise_ratio=0.5
-)
-
-drum_out = my_drum()
-stft_plot(drum_out)
-ipd.Audio(drum_out, rate=vca.sample_rate)
-# -
-
-# You can also use the **SquareSawVCO oscillator** in the drum module.
-
-
-# +
-my_drum = Drum(
-    pitch_adsr=ADSR(0.25, 0.25, 0.25, 0.25, alpha=3),
-    amp_adsr=ADSR(0.25, 0.25, 0.25, 0.25),
-    vco=SquareSawVCO(shape=0, midi_f0=24, mod_depth=12),
-    sustain_duration=1,
-)
-
-drum_out = my_drum()
-stft_plot(drum_out)
-ipd.Audio(drum_out, rate=vca.sample_rate)
-# -
-
-# Additionally, the Drum class can take any number of oscillators.
-
-# +
-my_drum = Drum(
-    pitch_adsr=ADSR(0.25, 0.25, 0.25, 0.25, alpha=3),
-    amp_adsr=ADSR(0.25, 0.25, 0.25, 0.25),
-    vco=[
-        SquareSawVCO(shape=0, midi_f0=23.95, mod_depth=12),
-        SquareSawVCO(shape=0, midi_f0=24.05, mod_depth=12)
-    ],
+    vco_1 = SquareSawVCO(shape=0, midi_f0=23.95, mod_depth=12),
+    vco_2 = SquareSawVCO(shape=0, midi_f0=24.05, mod_depth=12),
+    mixer = Mixer(ratio=0.5),
+    noise_module = NoiseModule(ratio=0.1),
     sustain_duration=1
 )
 

--- a/examples/examples.py
+++ b/examples/examples.py
@@ -15,7 +15,7 @@ import librosa.display
 import matplotlib.pyplot as plt
 import numpy as np
 
-from ddspdrum.module import ADSR, VCA, Drum, SineVCO, SquareSawVCO, NoiseModule, Mixer
+from ddspdrum.module import ADSR, VCA, Drum, SineVCO, SquareSawVCO, NoiseModule
 from ddspdrum.defaults import SAMPLE_RATE
 
 # -
@@ -134,7 +134,7 @@ my_drum = Drum(
     amp_adsr=ADSR(0.25, 0.25, 0.25, 0.25),
     vco_1 = SquareSawVCO(shape=0, midi_f0=23.95, mod_depth=12),
     vco_2 = SquareSawVCO(shape=0, midi_f0=24.05, mod_depth=12),
-    mixer = Mixer(ratio=0.5),
+    vco_1_ratio = 0.5,
     noise_module = NoiseModule(ratio=0.1),
     sustain_duration=1
 )

--- a/src/ddspdrum/defaults.py
+++ b/src/ddspdrum/defaults.py
@@ -6,5 +6,8 @@ SAMPLE_RATE = 44100
 # The control rate is the frequency at which modulations are applied
 CONTROL_RATE = 1000
 
-# To avoid log errors.
+# Small value to avoid log errors.
 EPSILON = 1e-6
+
+# Equal power coefficient. 1/sqrt(2)
+EQ_POW = 0.70710678118

--- a/src/ddspdrum/module.py
+++ b/src/ddspdrum/module.py
@@ -6,7 +6,7 @@ Synth modules.
 """
 
 from abc import abstractmethod
-from typing import List, Tuple
+from typing import Tuple
 
 import numpy as np
 from scipy.signal import resample
@@ -26,8 +26,10 @@ class SynthModule:
         self, sample_rate: int = SAMPLE_RATE, control_rate: int = CONTROL_RATE
     ):
         """
-        NOTE: __init__ should only set parameters.
-        We shouldn't be doing computations in __init__ because the can change when the parameters change.
+        NOTE:
+        __init__ should only set parameters.
+        We shouldn't be doing computations in __init__ because the
+        can change when the parameters change.
         """
         self.sample_rate = sample_rate
         self.control_rate = control_rate
@@ -332,15 +334,17 @@ class VCA(SynthModule):
         audio_in = fix_length(audio_in, len(amp))
         return amp * audio_in
 
+
 class NoiseModule(SynthModule):
     """
     Adds noise.
     """
+
     def __init__(
         self,
         ratio: float = 0.25,
         sample_rate: int = SAMPLE_RATE,
-        control_rate: int = CONTROL_RATE
+        control_rate: int = CONTROL_RATE,
     ):
         super().__init__(sample_rate=sample_rate, control_rate=control_rate)
 
@@ -362,16 +366,16 @@ class Synth:
     have the same sample and control rate.
     """
 
-    def __init__(self, modules: List[SynthModule]):
+    def __init__(self, modules: Tuple[SynthModule]):
         """
         NOTE: __init__ should only set parameters.
-        We shouldn't be doing computations in __init__ because the can change when the parameters change.
+        We shouldn't be doing computations in __init__ because
+        the computations will change when the parameters change.
         """
         # Check that we are not mixing different control rates or sample rates
         for m in modules[:1]:
             assert m.sample_rate == modules[0].sample_rate
             assert m.control_rate == modules[0].control_rate
-
 
 
 class Drum(Synth):
@@ -391,18 +395,14 @@ class Drum(Synth):
         vca: VCA = VCA(),
     ):
         super().__init__(
-            modules=[
-                pitch_adsr,
-                amp_adsr,
-                vco_1,
-                vco_2,
-                noise_module,
-                vca
-            ]
+            modules=[pitch_adsr, amp_adsr, vco_1, vco_2, noise_module, vca]
         )
         assert sustain_duration >= 0
         assert 0 <= vco_1_ratio <= 1.0
 
+        self.sustain_duration = sustain_duration
+        self.pitch_adsr = pitch_adsr
+        self.amp_adsr = amp_adsr
         self.vco_1 = vco_1
         self.vco_2 = vco_2
         self.vco_1_ratio = vco_1_ratio
@@ -412,18 +412,18 @@ class Drum(Synth):
     def __call__(self):
         # The convention for triggering a note event is that it has
         # the same sustain_duration for both ADSRs.
-        pitch_envelope = pitch_adsr(sustain_duration)
-        amp_envelope = amp_adsr(sustain_duration)
+        pitch_envelope = self.pitch_adsr(self.sustain_duration)
+        amp_envelope = self.amp_adsr(self.sustain_duration)
         pitch_envelope = fix_length(pitch_envelope, len(amp_envelope))
 
-        vco_1_out = vco_1(pitch_envelope)
-        vco_2_out = vco_2(pitch_envelope)
+        vco_1_out = self.vco_1(pitch_envelope)
+        vco_2_out = self.vco_2(pitch_envelope)
 
         audio_out = crossfade(vco_1_out, vco_2_out, self.vco_1_ratio)
 
         audio_out = self.noise_module(audio_out)
 
-        return self.vca(self.amp_envelope, audio_out)
+        return self.vca(amp_envelope, audio_out)
 
 
 class SVF(SynthModule):
@@ -555,8 +555,13 @@ class LowPassSVF(SVF):
         self_oscillate: bool = False,
         sample_rate: int = SAMPLE_RATE,
     ):
-        super().__init__(mode="LPF", cutoff=cutoff, resonance=resonance,
-                         self_oscillate=self_oscillate, sample_rate=sample_rate)
+        super().__init__(
+            mode="LPF",
+            cutoff=cutoff,
+            resonance=resonance,
+            self_oscillate=self_oscillate,
+            sample_rate=sample_rate,
+        )
 
 
 class HighPassSVF(SVF):
@@ -571,8 +576,13 @@ class HighPassSVF(SVF):
         self_oscillate: bool = False,
         sample_rate: int = SAMPLE_RATE,
     ):
-        super().__init__(mode="HPF", cutoff=cutoff, resonance=resonance,
-                         self_oscillate=self_oscillate, sample_rate=sample_rate)
+        super().__init__(
+            mode="HPF",
+            cutoff=cutoff,
+            resonance=resonance,
+            self_oscillate=self_oscillate,
+            sample_rate=sample_rate,
+        )
 
 
 class BandPassSVF(SVF):
@@ -587,8 +597,13 @@ class BandPassSVF(SVF):
         self_oscillate: bool = False,
         sample_rate: int = SAMPLE_RATE,
     ):
-        super().__init__(mode="BPF", cutoff=cutoff, resonance=resonance,
-                         self_oscillate=self_oscillate, sample_rate=sample_rate)
+        super().__init__(
+            mode="BPF",
+            cutoff=cutoff,
+            resonance=resonance,
+            self_oscillate=self_oscillate,
+            sample_rate=sample_rate,
+        )
 
 
 class BandRejectSVF(SVF):
@@ -603,8 +618,13 @@ class BandRejectSVF(SVF):
         self_oscillate: bool = False,
         sample_rate: int = SAMPLE_RATE,
     ):
-        super().__init__(mode="BSF", cutoff=cutoff, resonance=resonance,
-                         self_oscillate=self_oscillate, sample_rate=sample_rate)
+        super().__init__(
+            mode="BSF",
+            cutoff=cutoff,
+            resonance=resonance,
+            self_oscillate=self_oscillate,
+            sample_rate=sample_rate,
+        )
 
 
 class FIR(SynthModule):

--- a/src/ddspdrum/module.py
+++ b/src/ddspdrum/module.py
@@ -28,8 +28,8 @@ class SynthModule:
         """
         NOTE:
         __init__ should only set parameters.
-        We shouldn't be doing computations in __init__ because the
-        can change when the parameters change.
+        We shouldn't be doing computations in __init__ because
+        the computations will change when the parameters change.
         Instead, consider @property getters that use the instance's parameters.
         """
         self.sample_rate = sample_rate
@@ -372,6 +372,7 @@ class Synth:
         NOTE: __init__ should only set parameters.
         We shouldn't be doing computations in __init__ because
         the computations will change when the parameters change.
+        Instead, consider @property getters that use the instance's parameters.
         """
         # Check that we are not mixing different control rates or sample rates
         for m in modules[:1]:

--- a/src/ddspdrum/module.py
+++ b/src/ddspdrum/module.py
@@ -12,7 +12,7 @@ import numpy as np
 from scipy.signal import resample
 
 from ddspdrum.defaults import CONTROL_RATE, SAMPLE_RATE
-from ddspdrum.util import fix_length, midi_to_hz, crossfade
+from ddspdrum.util import crossfade, fix_length, midi_to_hz
 
 
 class SynthModule:

--- a/src/ddspdrum/module.py
+++ b/src/ddspdrum/module.py
@@ -30,6 +30,7 @@ class SynthModule:
         __init__ should only set parameters.
         We shouldn't be doing computations in __init__ because the
         can change when the parameters change.
+        Instead, consider @property getters that use the instance's parameters.
         """
         self.sample_rate = sample_rate
         self.control_rate = control_rate

--- a/src/ddspdrum/util.py
+++ b/src/ddspdrum/util.py
@@ -4,7 +4,7 @@ Utility functions for DSP related things
 
 import numpy as np
 
-from ddspdrum.defaults import EPSILON
+from ddspdrum.defaults import EPSILON, EQ_POW
 
 
 # What is amin here? And maybe we should convert it to a value in defaults?
@@ -60,3 +60,10 @@ def fix_length(signal: np.array, length: int) -> np.array:
         signal = signal[:length]
     assert signal.shape == (length,)
     return signal
+
+
+def crossfade(in_1, in_2, ratio):
+    """
+    Equal power cross-fade.
+    """
+    return EQ_POW * (np.sqrt(1 - ratio) * in_1 + np.sqrt(ratio) * in_2)


### PR DESCRIPTION
Added simple noise generator to the Drum class, plus the ability to accept an arbitrary number of oscillators.

(We may in fact want to fix this to two oscillators, with a mix parameter between them.)

(...)

(Still, sounds pretty cool. Check the examples.)