### PR TITLE
black + isort + flake8

### DIFF
--- a/examples/examples.py
+++ b/examples/examples.py
@@ -133,7 +133,6 @@ my_drum = Drum(
     amp_adsr=ADSR(0.25, 0.25, 0.25, 0.25),
     vco_1=SquareSawVCO(shape=0, midi_f0=23.95, mod_depth=12),
     vco_2=SquareSawVCO(shape=0, midi_f0=24.05, mod_depth=12),
-    vco_1_ratio=0.5,
     noise_module=NoiseModule(ratio=0.1),
     sustain_duration=1,
 )
@@ -330,3 +329,9 @@ svf = LowPassSVF(cutoff=45, resonance=50)
 kick = svf(signal, cutoff_mod=cutoff_mod, cutoff_mod_amount=150)
 plt.plot(kick)
 ipd.Audio(kick, rate=sample_rate)
+
+
+
+
+
+

--- a/src/ddspdrum/parameter.py
+++ b/src/ddspdrum/parameter.py
@@ -13,7 +13,8 @@ class Parameter:
 
     Parameters
     ----------
-    value (float)   :   initial value of this parameter
+    name    (str)   :   Unique name to give to this parameter.
+    value   (float) :   initial value of this parameter
     minimum (float) :   minimum value that this parameter can take on
     maximum (float) :   maximum value that this parameter can take on
     scale   (float) :   scaling to apply when converting to and from a value with
@@ -22,26 +23,25 @@ class Parameter:
                         lower range of the parameter, whereas a scale value greater 1
                         is an exponential relationship that fills more of the higher
                         range of the parameter.
-    name    (str)   :   Optional name to give to this parameter.
     """
 
     def __init__(
         self,
+        name: str,
         value: float,
         minimum: float,
         maximum: float,
         scale: float = 1,
-        name: str = "",
     ):
+        self.name = name
+        self.value = np.clip(value, minimum, maximum)
         self.minimum = minimum
         self.maximum = maximum
         self.scale = scale
-        self.value = np.clip(value, minimum, maximum)
-        self.name = name
 
     def __str__(self):
         name = "{}, ".format(self.name) if self.name else ""
-        return "Parameter: {}Value: {}, Min: {}, Max: {}, Scale: {}".format(
+        return "Parameter: {}, Value: {}, Min: {}, Max: {}, Scale: {}".format(
             name, self.value, self.minimum, self.maximum, self.scale
         )
 

--- a/src/ddspdrum/parameter.py
+++ b/src/ddspdrum/parameter.py
@@ -26,12 +26,12 @@ class Parameter:
     """
 
     def __init__(
-            self,
-            value: float,
-            minimum: float,
-            maximum: float,
-            scale: float = 1,
-            name: str = ""
+        self,
+        value: float,
+        minimum: float,
+        maximum: float,
+        scale: float = 1,
+        name: str = "",
     ):
         self.minimum = minimum
         self.maximum = maximum
@@ -42,11 +42,7 @@ class Parameter:
     def __str__(self):
         name = "{}, ".format(self.name) if self.name else ""
         return "Parameter: {}Value: {}, Min: {}, Max: {}, Scale: {}".format(
-            name,
-            self.value,
-            self.minimum,
-            self.maximum,
-            self.scale
+            name, self.value, self.minimum, self.maximum, self.scale
         )
 
     def set_value(self, new_value):


### PR DESCRIPTION
This merges into `parameters` not `main`.

I simply run:
```
black src/ddspdrum/*py; isort src/ddspdrum/*py ; flake8 src/ddspdrum/*py
```

to standardize the formatting. Formatting PRs should be separate from code change PRs.

Even tho the *diff* coverage is only 91% forget it, the overall code coverage is good. This is fine to merge