### PR TITLE
DummyModule

### DIFF
--- a/examples/examples.py
+++ b/examples/examples.py
@@ -111,18 +111,6 @@ ipd.Audio(vca_out, rate=vca.sample_rate)
 
 # Alternately, you can just use the Drum class that composes all these modules together automatically.
 
-import ddspdrum.module
-from ddspdrum.module import DummyModule
-drum_params: DummyModule= DummyModule(
-            params=[
-            {"parameter_id": "vco_1_ratio",
-             "value": 0.5,
-             "minimum": 0.0,
-             "maximum": 1.0,
-             }]
-            )
-drum_params.list_parameters()
-
 # +
 my_drum = Drum(
     pitch_adsr=ADSR(0.25, 0.25, 0.25, 0.25, alpha=3),

--- a/examples/examples.py
+++ b/examples/examples.py
@@ -111,6 +111,18 @@ ipd.Audio(vca_out, rate=vca.sample_rate)
 
 # Alternately, you can just use the Drum class that composes all these modules together automatically.
 
+import ddspdrum.module
+from ddspdrum.module import DummyModule
+drum_params: DummyModule= DummyModule(
+            params=[
+            {"parameter_id": "vco_1_ratio",
+             "value": 0.5,
+             "minimum": 0.0,
+             "maximum": 1.0,
+             }]
+            )
+drum_params.list_parameters()
+
 # +
 my_drum = Drum(
     pitch_adsr=ADSR(0.25, 0.25, 0.25, 0.25, alpha=3),
@@ -133,7 +145,6 @@ my_drum = Drum(
     amp_adsr=ADSR(0.25, 0.25, 0.25, 0.25),
     vco_1=SquareSawVCO(shape=0, midi_f0=23.95, mod_depth=12),
     vco_2=SquareSawVCO(shape=0, midi_f0=24.05, mod_depth=12),
-    vco_1_ratio=0.5,
     noise_module=NoiseModule(ratio=0.1),
     sustain_duration=1,
 )
@@ -330,3 +341,9 @@ svf = LowPassSVF(cutoff=45, resonance=50)
 kick = svf(signal, cutoff_mod=cutoff_mod, cutoff_mod_amount=150)
 plt.plot(kick)
 ipd.Audio(kick, rate=sample_rate)
+
+
+
+
+
+

--- a/src/ddspdrum/module.py
+++ b/src/ddspdrum/module.py
@@ -8,7 +8,7 @@ Synth modules.
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Tuple
+from typing import Dict, List, Tuple
 
 import numpy as np
 from scipy.signal import resample
@@ -62,8 +62,14 @@ class SynthModule:
             )
             return resample(control, num_samples)
 
-    def add_parameter(self, parameter_id: str, value: float, minimum: float,
-                      maximum: float, scale: float = 1):
+    def add_parameter(
+        self,
+        parameter_id: str,
+        value: float,
+        minimum: float,
+        maximum: float,
+        scale: float = 1,
+    ):
         """
         Add a new parameter to this module.
 
@@ -78,11 +84,13 @@ class SynthModule:
         if parameter_id in self.parameters:
             raise ValueError("parameter_id: {} already used".format(parameter_id))
 
-        self.parameters[parameter_id] = Parameter(value, minimum, maximum,
-                                                  scale, parameter_id)
+        self.parameters[parameter_id] = Parameter(
+            value, minimum, maximum, scale, parameter_id
+        )
 
-    def connect_parameter(self, parameter_id: str, module: SynthModule,
-                          module_parameter_id: str):
+    def connect_parameter(
+        self, parameter_id: str, module: SynthModule, module_parameter_id: str
+    ):
         """
         Create a named parameter for this synthesizer that is connected to a parameter
         in an underlying synth module
@@ -97,8 +105,11 @@ class SynthModule:
             raise ValueError("parameter_id: {} already used".format(parameter_id))
 
         if module_parameter_id not in module.parameters:
-            raise KeyError("parameter_id: {} not a parameter in {}".format(
-                module_parameter_id, module))
+            raise KeyError(
+                "parameter_id: {} not a parameter in {}".format(
+                    module_parameter_id, module
+                )
+            )
 
         self.parameters[parameter_id] = module.get_parameter(module_parameter_id)
 
@@ -149,6 +160,7 @@ class SynthModule:
         Return a dictionary of the parameters as strings
         """
         return {key: str(self.parameters[key]) for key in self.parameters}
+
 
 class ADSR(SynthModule):
     """
@@ -226,28 +238,30 @@ class ADSR(SynthModule):
         t = np.linspace(
             0, duration, int(round(duration * self.control_rate)), endpoint=False
         )
-        return (t / duration) ** self.parameters['alpha'].value
+        return (t / duration) ** self.parameters["alpha"].value
 
     @property
     def attack(self):
-        return self._ramp(self.parameters['attack'].value)
+        return self._ramp(self.parameters["attack"].value)
 
     @property
     def decay(self):
         # `d`-length reverse ramp, scaled and shifted to descend from 1 to `s`.
-        decay = self.parameters['decay'].value
-        sustain = self.parameters['sustain'].value
+        decay = self.parameters["decay"].value
+        sustain = self.parameters["sustain"].value
         return self._ramp(decay)[::-1] * (1 - sustain) + sustain
 
     def sustain(self, duration):
-        return np.full(round(int(duration * CONTROL_RATE)),
-                       fill_value=self.parameters['sustain'].value)
+        return np.full(
+            round(int(duration * CONTROL_RATE)),
+            fill_value=self.parameters["sustain"].value,
+        )
 
     @property
     def release(self):
         # `r`-length reverse ramp, scaled and shifted to descend from `s` to 0.
-        sustain = self.parameters['sustain'].value
-        release = self.parameters['release'].value
+        sustain = self.parameters["sustain"].value
+        release = self.parameters["release"].value
         return self._ramp(release)[::-1] * sustain
 
     @property
@@ -259,11 +273,9 @@ class ADSR(SynthModule):
         return self.release
 
     def __str__(self):
-        return (
-            f"""ADSR(a={self.parameters['attack']}, d={self.parameters['decay']},
+        return f"""ADSR(a={self.parameters['attack']}, d={self.parameters['decay']},
                 s={self.parameters['sustain']}, r={self.parameters['release']},
                 alpha={self.get_parameter('alpha')})"""
-        )
 
 
 class VCO(SynthModule):
@@ -328,8 +340,8 @@ class VCO(SynthModule):
 
         assert (mod_signal >= 0).all() and (mod_signal <= 1).all()
 
-        modulation = self.parameters['mod_depth'].value * mod_signal
-        control_as_midi = self.parameters['pitch'].value + modulation
+        modulation = self.parameters["mod_depth"].value * mod_signal
+        control_as_midi = self.parameters["pitch"].value + modulation
         control_as_frequency = midi_to_hz(control_as_midi)
         cosine_argument = self.make_argument(control_as_frequency) + phase
 
@@ -389,13 +401,13 @@ class SquareSawVCO(VCO):
 
     def oscillator(self, argument):
         square = np.tanh(np.pi * self.k * np.sin(argument) / 2)
-        shape = self.parameters['shape'].value
+        shape = self.parameters["shape"].value
         return (1 - shape / 2) * square * (1 + shape * np.cos(argument))
 
     @property
     def k(self):
         # What does k mean here? Can we give it a better name?
-        pitch = self.parameters['pitch'].value + self.parameters['mod_depth'].value
+        pitch = self.parameters["pitch"].value + self.parameters["mod_depth"].value
         f0 = midi_to_hz(pitch)
         return 12000 / (f0 * np.log10(f0))
 
@@ -434,7 +446,7 @@ class NoiseModule(SynthModule):
 
     def __call__(self, audio_in: np.ndarray):
         noise = self.noise_of_length(audio_in)
-        return crossfade(audio_in, noise, self.parameters['ratio'].value)
+        return crossfade(audio_in, noise, self.parameters["ratio"].value)
 
     @staticmethod
     def noise_of_length(audio_in: np.ndarray):
@@ -467,6 +479,7 @@ class DummyModule(SynthModule):
 
     def __call__(self):
         assert False
+
 
 class Synth:
     """
@@ -564,7 +577,7 @@ class Drum(Synth):
     def __call__(self):
         # The convention for triggering a note event is that it has
         # the same sustain_duration for both ADSRs.
-        sustain_duration = self.parameters['sustain_duration'].value
+        sustain_duration = self.parameters["sustain_duration"].value
         pitch_envelope = self.pitch_adsr(sustain_duration)
         amp_envelope = self.amp_adsr(sustain_duration)
         pitch_envelope = fix_length(pitch_envelope, len(amp_envelope))
@@ -572,9 +585,9 @@ class Drum(Synth):
         vco_1_out = self.vco_1(pitch_envelope)
         vco_2_out = self.vco_2(pitch_envelope)
 
-        audio_out = crossfade(vco_1_out,
-                              vco_2_out,
-                              self.parameters['vco_1_ratio'].value)
+        audio_out = crossfade(
+            vco_1_out, vco_2_out, self.parameters["vco_1_ratio"].value
+        )
 
         audio_out = self.noise_module(audio_out)
 
@@ -641,7 +654,7 @@ class SVF(SynthModule):
         y = np.zeros_like(audio)
 
         # Calculate initial coefficients
-        cutoff = self.parameters['cutoff'].value
+        cutoff = self.parameters["cutoff"].value
         coeff0, coeff1, rho = self.calculate_coefficients(cutoff)
 
         # Check if there is a filter cutoff envelope to apply
@@ -687,7 +700,7 @@ class SVF(SynthModule):
         """
 
         g = np.tan(np.pi * cutoff / self.sample_rate)
-        resonance = self.parameters['resonance'].value
+        resonance = self.parameters["resonance"].value
         R = 0.0 if self.self_oscillate else 1.0 / (2.0 * resonance)
         coeff0 = 1.0 / (1.0 + 2.0 * R * g + g * g)
         coeff1 = g
@@ -818,8 +831,9 @@ class FIR(SynthModule):
         audio (np.ndarray)  :   audio samples to filter
         """
 
-        impulse = self.windowed_sinc(self.parameters['cutoff'].value,
-                                     self.parameters['length'].value)
+        impulse = self.windowed_sinc(
+            self.parameters["cutoff"].value, self.parameters["length"].value
+        )
         y = np.convolve(audio, impulse)
         return y
 
@@ -888,7 +902,7 @@ class MovingAverage(SynthModule):
 
         audio (np.ndarray)  :   audio samples to filter
         """
-        length = self.parameters['length'].value
+        length = self.parameters["length"].value
         impulse = np.ones(length) / length
         y = np.convolve(audio, impulse)
         return y

--- a/src/ddspdrum/module.py
+++ b/src/ddspdrum/module.py
@@ -150,7 +150,6 @@ class SynthModule:
         """
         return {key: str(self.parameters[key]) for key in self.parameters}
 
-
 class ADSR(SynthModule):
     """
     Envelope class for building a control rate ADSR signal
@@ -442,7 +441,34 @@ class NoiseModule(SynthModule):
         return np.random.rand(len(audio_in))
 
 
-class Synth(SynthModule):
+class DummyModule(SynthModule):
+    """
+    A dummy module just encapsulates some parameters and don't create sound.
+    This is a temporary workaround that allows a Synth to contain parameters
+    without nesting SynthModules and without forcing Synth to be a SynthModule.
+    """
+
+    def __init__(
+        self,
+        sample_rate: int = SAMPLE_RATE,
+        control_rate: int = CONTROL_RATE,
+        *params: List[Dict],
+    ):
+        """
+        Parameters
+        ----------
+        dict                :   List of parameter dictionaries, for
+                                `self.add_parameter`.
+                                TODO: Take this as a list of Parameters instead?
+        """
+        super().__init__(sample_rate=sample_rate, control_rate=control_rate)
+        for param in params:
+            self.add_parameter(**param)
+
+    def __call__(self):
+        assert False
+
+class Synth:
     """
     A base class for a modular synth, ensuring that all modules
     have the same sample and control rate.
@@ -491,7 +517,12 @@ class Drum(Synth):
         assert sustain_duration >= 0
         assert 0 <= vco_1_ratio <= 1.0
 
+        # We assume that sustain duration is a hyper-parameter,
+        # with the mindset that if you are trying to learn to
+        # synthesize a sound, you won't be adjusting the sustain_duration.
+        # However, this is easily changed if desired.
         self.sustain_duration = sustain_duration
+
         self.pitch_adsr = pitch_adsr
         self.amp_adsr = amp_adsr
         self.vco_1 = vco_1

--- a/src/ddspdrum/module.py
+++ b/src/ddspdrum/module.py
@@ -6,6 +6,7 @@ Synth modules.
 """
 
 from __future__ import annotations
+
 from abc import abstractmethod
 from typing import Tuple
 

--- a/src/ddspdrum/module.py
+++ b/src/ddspdrum/module.py
@@ -516,14 +516,16 @@ class Drum(Synth):
     def __init__(
         self,
         sustain_duration: float,
-        drum_params: DummyModule= DummyModule(
+        drum_params: DummyModule = DummyModule(
             params=[
-            {"parameter_id": "vco_1_ratio",
-             "value": 0.5,
-             "minimum": 0.0,
-             "maximum": 1.0,
-             }]
-            ),
+                {
+                    "parameter_id": "vco_1_ratio",
+                    "value": 0.5,
+                    "minimum": 0.0,
+                    "maximum": 1.0,
+                }
+            ]
+        ),
         pitch_adsr: ADSR = ADSR(),
         amp_adsr: ADSR = ADSR(),
         vco_1: VCO = SineVCO(),

--- a/src/ddspdrum/module.py
+++ b/src/ddspdrum/module.py
@@ -261,7 +261,7 @@ class ADSR(SynthModule):
     def __str__(self):
         return (
             f"""ADSR(a={self.parameters['attack']}, d={self.parameters['decay']},
-                s={self.parameters['sustain']}, r={self.parameters['release']}, 
+                s={self.parameters['sustain']}, r={self.parameters['release']},
                 alpha={self.get_parameter('alpha')})"""
         )
 

--- a/src/ddspdrum/parameter.py
+++ b/src/ddspdrum/parameter.py
@@ -26,12 +26,12 @@ class Parameter:
     """
 
     def __init__(
-            self,
-            value: float,
-            minimum: float,
-            maximum: float,
-            scale: float = 1,
-            name: str = ""
+        self,
+        value: float,
+        minimum: float,
+        maximum: float,
+        scale: float = 1,
+        name: str = "",
     ):
         self.minimum = minimum
         self.maximum = maximum
@@ -42,11 +42,7 @@ class Parameter:
     def __str__(self):
         name = "{}, ".format(self.name) if self.name else ""
         return "Parameter: {}Value: {}, Min: {}, Max: {}, Scale: {}".format(
-            name,
-            self.value,
-            self.minimum,
-            self.maximum,
-            self.scale
+            name, self.value, self.minimum, self.maximum, self.scale
         )
 
     def set_value(self, new_value):


### PR DESCRIPTION
This is an incremental PR off `parameters_black` which creates `DummyModule`. This is a first step towards removing nested SynthModules. `DummyModule` holds all parameters of a synth but does not generate any sound.