### PR TITLE
self.add_parameters

### DIFF
--- a/src/ddspdrum/module.py
+++ b/src/ddspdrum/module.py
@@ -26,9 +26,7 @@ class SynthModule:
     """
 
     def __init__(
-        self,
-        sample_rate: int = SAMPLE_RATE,
-        control_rate: int = CONTROL_RATE
+        self, sample_rate: int = SAMPLE_RATE, control_rate: int = CONTROL_RATE
     ):
         """
         NOTE:
@@ -174,13 +172,15 @@ class ADSR(SynthModule):
                                 exponential.
         """
         super().__init__(sample_rate=sample_rate, control_rate=control_rate)
-        self.add_parameters([
-        Parameter("attack", a, 0, 20, scale=0.5),
-        Parameter("decay", d, 0, 20, scale=0.5),
-        Parameter("sustain", s, 0, 1),
-        Parameter("release", r, 0, 20, scale=0.5),
-        Parameter("alpha", alpha, 0, 10),
-        ])
+        self.add_parameters(
+            [
+                Parameter("attack", a, 0, 20, scale=0.5),
+                Parameter("decay", d, 0, 20, scale=0.5),
+                Parameter("sustain", s, 0, 1),
+                Parameter("release", r, 0, 20, scale=0.5),
+                Parameter("alpha", alpha, 0, 10),
+            ]
+        )
 
     def __call__(self, sustain_duration: float = 0):
         """Generate an envelope that sustains for a given duration in seconds.
@@ -296,10 +296,12 @@ class VCO(SynthModule):
         control_rate: int = CONTROL_RATE,
     ):
         super().__init__(sample_rate=sample_rate, control_rate=control_rate)
-        self.add_parameters([
-        Parameter("pitch", midi_f0, 0, 127),
-        Parameter("mod_depth", mod_depth, 0, 127),
-        ])
+        self.add_parameters(
+            [
+                Parameter("pitch", midi_f0, 0, 127),
+                Parameter("mod_depth", mod_depth, 0, 127),
+            ]
+        )
         # TODO: Make this a parameter too?
         self.phase = phase
 
@@ -387,9 +389,11 @@ class SquareSawVCO(VCO):
         phase: float = 0,
     ):
         super().__init__(midi_f0=midi_f0, mod_depth=mod_depth, phase=phase)
-        self.add_parameters([
-        Parameter("shape", shape, 0, 1),
-        ])
+        self.add_parameters(
+            [
+                Parameter("shape", shape, 0, 1),
+            ]
+        )
 
     def oscillator(self, argument):
         square = np.tanh(np.pi * self.k * np.sin(argument) / 2)
@@ -434,9 +438,11 @@ class NoiseModule(SynthModule):
         control_rate: int = CONTROL_RATE,
     ):
         super().__init__(sample_rate=sample_rate, control_rate=control_rate)
-        self.add_parameters([
-        Parameter("ratio", ratio, 0, 1),
-        ])
+        self.add_parameters(
+            [
+                Parameter("ratio", ratio, 0, 1),
+            ]
+        )
 
     def __call__(self, audio_in: np.ndarray):
         noise = self.noise_of_length(audio_in)
@@ -513,10 +519,10 @@ class Drum(Synth):
         drum_params: DummyModule = DummyModule(
             parameters=[
                 Parameter(
-                    name= "vco_1_ratio",
-                    value= 0.5,
-                    minimum= 0.0,
-                    maximum= 1.0,
+                    name="vco_1_ratio",
+                    value=0.5,
+                    minimum=0.0,
+                    maximum=1.0,
                 )
             ]
         ),
@@ -627,10 +633,12 @@ class SVF(SynthModule):
         super().__init__(sample_rate=sample_rate, control_rate=control_rate)
         self.mode = mode
         self.self_oscillate = self_oscillate
-        self.add_parameters([
-        Parameter("cutoff", cutoff, 5, self.sample_rate / 2.0, scale=0.5),
-        Parameter("resonance", resonance, 0.5, 1000, scale=0.25),
-        ])
+        self.add_parameters(
+            [
+                Parameter("cutoff", cutoff, 5, self.sample_rate / 2.0, scale=0.5),
+                Parameter("resonance", resonance, 0.5, 1000, scale=0.25),
+            ]
+        )
 
     def __call__(
         self,
@@ -819,10 +827,12 @@ class FIR(SynthModule):
         control_rate: int = CONTROL_RATE,
     ):
         super().__init__(sample_rate=sample_rate, control_rate=control_rate)
-        self.add_parameters([
-        Parameter("cutoff", cutoff, 5, sample_rate / 2.0, scale=0.5),
-        Parameter("length", filter_length, 4, 4096),
-        ])
+        self.add_parameters(
+            [
+                Parameter("cutoff", cutoff, 5, sample_rate / 2.0, scale=0.5),
+                Parameter("length", filter_length, 4, 4096),
+            ]
+        )
 
     def __call__(self, audio: np.ndarray) -> np.ndarray:
         """
@@ -895,9 +905,11 @@ class MovingAverage(SynthModule):
         control_rate: int = CONTROL_RATE,
     ):
         super().__init__(sample_rate=sample_rate, control_rate=control_rate)
-        self.add_parameters([
-        Parameter("length", filter_length, 1, 4096),
-        ])
+        self.add_parameters(
+            [
+                Parameter("length", filter_length, 1, 4096),
+            ]
+        )
 
     def __call__(self, audio: np.ndarray) -> np.ndarray:
         """

--- a/src/ddspdrum/module.py
+++ b/src/ddspdrum/module.py
@@ -26,18 +26,28 @@ class SynthModule:
     """
 
     def __init__(
-        self, sample_rate: int = SAMPLE_RATE, control_rate: int = CONTROL_RATE
+        self,
+        sample_rate: int = SAMPLE_RATE,
+        control_rate: int = CONTROL_RATE
     ):
         """
         NOTE:
         __init__ should only set parameters.
         We shouldn't be doing computations in __init__ because
         the computations will change when the parameters change.
-        Instead, consider @property getters that use the instance's parameters.
         """
         self.sample_rate = sample_rate
         self.control_rate = control_rate
-        self.parameters = {}
+        self.parameters: Dict[Parameter] = {}
+
+    def add_parameters(self, parameters: List[Parameter]):
+        """
+        Add parameters to this SynthModule's parameters dictionary.
+        (Since there is inheritance, this might happen several times.)
+        """
+        for parameter in parameters:
+            assert parameter.name not in self.parameters
+            self.parameters[parameter.name] = parameter
 
     def control_to_sample_rate(self, control: np.array) -> np.array:
         """
@@ -61,32 +71,6 @@ class SynthModule:
                 round(len(control) * self.sample_rate / self.control_rate)
             )
             return resample(control, num_samples)
-
-    def add_parameter(
-        self,
-        parameter_id: str,
-        value: float,
-        minimum: float,
-        maximum: float,
-        scale: float = 1,
-    ):
-        """
-        Add a new parameter to this module.
-
-        Parameters
-        ----------
-        parameter_id (str)  :   id to save this parameter as
-        value (float)       :   initial value for this parameter
-        minimum (float)     :   minimum value that this parameter can take
-        maximum (float)     :   maximum value that this parameter can take
-        scale (float)       :   scaling when converting between [0,1] range
-        """
-        if parameter_id in self.parameters:
-            raise ValueError("parameter_id: {} already used".format(parameter_id))
-
-        self.parameters[parameter_id] = Parameter(
-            value, minimum, maximum, scale, parameter_id
-        )
 
     def connect_parameter(
         self, parameter_id: str, module: SynthModule, module_parameter_id: str
@@ -190,11 +174,13 @@ class ADSR(SynthModule):
                                 exponential.
         """
         super().__init__(sample_rate=sample_rate, control_rate=control_rate)
-        self.add_parameter("attack", a, 0, 20, scale=0.5)
-        self.add_parameter("decay", d, 0, 20, scale=0.5)
-        self.add_parameter("sustain", s, 0, 1)
-        self.add_parameter("release", r, 0, 20, scale=0.5)
-        self.add_parameter("alpha", alpha, 0, 10)
+        self.add_parameters([
+        Parameter("attack", a, 0, 20, scale=0.5),
+        Parameter("decay", d, 0, 20, scale=0.5),
+        Parameter("sustain", s, 0, 1),
+        Parameter("release", r, 0, 20, scale=0.5),
+        Parameter("alpha", alpha, 0, 10),
+        ])
 
     def __call__(self, sustain_duration: float = 0):
         """Generate an envelope that sustains for a given duration in seconds.
@@ -310,8 +296,11 @@ class VCO(SynthModule):
         control_rate: int = CONTROL_RATE,
     ):
         super().__init__(sample_rate=sample_rate, control_rate=control_rate)
-        self.add_parameter("pitch", midi_f0, 0, 127)
-        self.add_parameter("mod_depth", mod_depth, 0, 127)
+        self.add_parameters([
+        Parameter("pitch", midi_f0, 0, 127),
+        Parameter("mod_depth", mod_depth, 0, 127),
+        ])
+        # TODO: Make this a parameter too?
         self.phase = phase
 
     def __call__(self, mod_signal: np.array, phase: float = 0) -> np.array:
@@ -340,6 +329,7 @@ class VCO(SynthModule):
 
         assert (mod_signal >= 0).all() and (mod_signal <= 1).all()
 
+        print(self.parameters)
         modulation = self.parameters["mod_depth"].value * mod_signal
         control_as_midi = self.parameters["pitch"].value + modulation
         control_as_frequency = midi_to_hz(control_as_midi)
@@ -397,7 +387,9 @@ class SquareSawVCO(VCO):
         phase: float = 0,
     ):
         super().__init__(midi_f0=midi_f0, mod_depth=mod_depth, phase=phase)
-        self.add_parameter("shape", shape, 0, 1)
+        self.add_parameters([
+        Parameter("shape", shape, 0, 1),
+        ])
 
     def oscillator(self, argument):
         square = np.tanh(np.pi * self.k * np.sin(argument) / 2)
@@ -442,7 +434,9 @@ class NoiseModule(SynthModule):
         control_rate: int = CONTROL_RATE,
     ):
         super().__init__(sample_rate=sample_rate, control_rate=control_rate)
-        self.add_parameter("ratio", ratio, 0, 1)
+        self.add_parameters([
+        Parameter("ratio", ratio, 0, 1),
+        ])
 
     def __call__(self, audio_in: np.ndarray):
         noise = self.noise_of_length(audio_in)
@@ -462,7 +456,7 @@ class DummyModule(SynthModule):
 
     def __init__(
         self,
-        params: List[Dict],
+        parameters: List[Parameter],
         sample_rate: int = SAMPLE_RATE,
         control_rate: int = CONTROL_RATE,
     ):
@@ -470,12 +464,11 @@ class DummyModule(SynthModule):
         Parameters
         ----------
         dict                :   List of parameter dictionaries, for
-                                `self.add_parameter`.
+                                `Parameter`.,
                                 TODO: Take this as a list of Parameters instead?
         """
         super().__init__(sample_rate=sample_rate, control_rate=control_rate)
-        for param in params:
-            self.add_parameter(**param)
+        self.add_parameters(parameters)
 
     def __call__(self):
         assert False
@@ -500,6 +493,7 @@ class Synth(SynthModule):
         super().__init__(sample_rate=sample_rate, control_rate=control_rate)
 
         # Parameter list
+        # TODO: We can remove this later
         self.parameters = {}
 
         # Check that we are not mixing different control rates or sample rates
@@ -517,13 +511,13 @@ class Drum(Synth):
         self,
         sustain_duration: float,
         drum_params: DummyModule = DummyModule(
-            params=[
-                {
-                    "parameter_id": "vco_1_ratio",
-                    "value": 0.5,
-                    "minimum": 0.0,
-                    "maximum": 1.0,
-                }
+            parameters=[
+                Parameter(
+                    name= "vco_1_ratio",
+                    value= 0.5,
+                    minimum= 0.0,
+                    maximum= 1.0,
+                )
             ]
         ),
         pitch_adsr: ADSR = ADSR(),
@@ -633,8 +627,10 @@ class SVF(SynthModule):
         super().__init__(sample_rate=sample_rate, control_rate=control_rate)
         self.mode = mode
         self.self_oscillate = self_oscillate
-        self.add_parameter("cutoff", cutoff, 5, self.sample_rate / 2.0, scale=0.5)
-        self.add_parameter("resonance", resonance, 0.5, 1000, scale=0.25)
+        self.add_parameters([
+        Parameter("cutoff", cutoff, 5, self.sample_rate / 2.0, scale=0.5),
+        Parameter("resonance", resonance, 0.5, 1000, scale=0.25),
+        ])
 
     def __call__(
         self,
@@ -823,8 +819,10 @@ class FIR(SynthModule):
         control_rate: int = CONTROL_RATE,
     ):
         super().__init__(sample_rate=sample_rate, control_rate=control_rate)
-        self.add_parameter("cutoff", cutoff, 5, sample_rate / 2.0, scale=0.5)
-        self.add_parameter("length", filter_length, 4, 4096)
+        self.add_parameters([
+        Parameter("cutoff", cutoff, 5, sample_rate / 2.0, scale=0.5),
+        Parameter("length", filter_length, 4, 4096),
+        ])
 
     def __call__(self, audio: np.ndarray) -> np.ndarray:
         """
@@ -897,7 +895,9 @@ class MovingAverage(SynthModule):
         control_rate: int = CONTROL_RATE,
     ):
         super().__init__(sample_rate=sample_rate, control_rate=control_rate)
-        self.add_parameter("length", filter_length, 1, 4096)
+        self.add_parameters([
+        Parameter("length", filter_length, 1, 4096),
+        ])
 
     def __call__(self, audio: np.ndarray) -> np.ndarray:
         """

--- a/src/ddspdrum/parameter.py
+++ b/src/ddspdrum/parameter.py
@@ -13,7 +13,8 @@ class Parameter:
 
     Parameters
     ----------
-    value (float)   :   initial value of this parameter
+    name    (str)   :   Unique name to give to this parameter.
+    value   (float) :   initial value of this parameter
     minimum (float) :   minimum value that this parameter can take on
     maximum (float) :   maximum value that this parameter can take on
     scale   (float) :   scaling to apply when converting to and from a value with
@@ -22,26 +23,25 @@ class Parameter:
                         lower range of the parameter, whereas a scale value greater 1
                         is an exponential relationship that fills more of the higher
                         range of the parameter.
-    name    (str)   :   Optional name to give to this parameter.
     """
 
     def __init__(
         self,
+        name: str,
         value: float,
         minimum: float,
         maximum: float,
         scale: float = 1,
-        name: str = "",
     ):
+        self.name = name
+        self.value = np.clip(value, minimum, maximum)
         self.minimum = minimum
         self.maximum = maximum
         self.scale = scale
-        self.value = np.clip(value, minimum, maximum)
-        self.name = name
 
     def __str__(self):
         name = "{}, ".format(self.name) if self.name else ""
-        return "Parameter: {}Value: {}, Min: {}, Max: {}, Scale: {}".format(
+        return "Parameter: {}, Value: {}, Min: {}, Max: {}, Scale: {}".format(
             name, self.value, self.minimum, self.maximum, self.scale
         )
 


### PR DESCRIPTION
`self.add_parameters` now takes a list of `Parameter`. Although this doesn't remove any boilerplate (in particular because each level of inheritance might add more params), I think it's safer to be explicit and use Parameter class, rather than having a few layers of indirection with unnamed variables and changing variable order.

So this doesn't really add or remove surface area, it's just a little safer.