### PR TITLE
Envelope behaviour

### DIFF
--- a/examples/examples.py
+++ b/examples/examples.py
@@ -38,8 +38,8 @@ def stft_plot(signal, sample_rate=SAMPLE_RATE):
 
 
 # Synthesis parameters.
-a = 0.01
-d = 0.05
+a = 0.1
+d = 0.1
 s = 0.75
 r = 0.5
 alpha = 3
@@ -56,10 +56,25 @@ sustain_duration = 0.5
 #
 # Envelopes are used to modulate a variety of signals; usually one of pitch, amplitude, or filter cutoff frequency. In
 # this notebook we will use the same envelope to modulate several different audio parameters.
+#
+# ### A note about note-on, note-off behaviour 
+#
+# By default, this envelope reacts as if it was triggered with midi, for example playing a keyboard. Each midi event has a beginning and end: note-on, when you press the key down; and note-off, when you release the key. `sustain_duration` is the amount of time that the key is depressed. During the note-on, the envelope moves through the attack and decay sections of the envelope. This leads to musically-intuitive, but programatically-counterintuitive behaviour.
+#
+# Assume attack is 0.5 seconds, and decay is 0.5 seconds. If a note is held for 0.75 seconds, the envelope won't traverse through the entire attack-and-decay phase (specifically, it will execute the entire attack, and 0.25 seconds of the decay).
+#
+# If this is confusing, don't worry about it. ADSR's do a lot of work behind the scenes to make the playing experience feel natural. Alternately, you may specify one-shot mode (see below), which is more typical of drum machines. 
 
 # Envelope test
 adsr = ADSR(a, d, s, r, alpha)
 envelope = adsr(sustain_duration)
+time_plot(envelope, adsr.sample_rate)
+
+# ### One-Shot Mode
+#
+# Alternately, you can specify a sustain time of "0" which will switch the envelope to one-shot mode. In this case, the envelope moves through the entire attack, decay, and release.
+
+envelope = adsr(sustain_duration = 0)
 time_plot(envelope, adsr.sample_rate)
 
 # SineVCO test

--- a/examples/examples.py
+++ b/examples/examples.py
@@ -62,7 +62,7 @@ dur = a + d + r + sustain_duration
 # Envelope test
 adsr = ADSR(a, d, s, r, alpha)
 envelope = adsr(sustain_duration)
-time_plot(envelope, adsr.control_rate)
+time_plot(envelope, adsr.sample_rate)
 
 # SineVCO test
 midi_f0 = 12

--- a/examples/examples.py
+++ b/examples/examples.py
@@ -43,9 +43,7 @@ d = 0.05
 s = 0.75
 r = 0.5
 alpha = 3
-sustain_duration = 0
-
-dur = a + d + r + sustain_duration
+sustain_duration = 0.5
 
 # ## The Envelope
 # Our module is based on an ADSR envelope, standing for "attack, decay, sustain, release," which is specified by four
@@ -78,7 +76,7 @@ ipd.Audio(sine_out, rate=sine_vco.sample_rate)
 # SquareSawVCO test: shape 0 --> square, 1 --> saw.
 
 shape = 0
-midi_f0 = 55
+midi_f0 = 24
 sqs = SquareSawVCO(shape=shape, midi_f0=midi_f0, mod_depth=6)
 sqs_out = sqs(envelope, phase=0)
 # -

--- a/src/ddspdrum/defaults.py
+++ b/src/ddspdrum/defaults.py
@@ -1,10 +1,7 @@
 """
 Default parameters
 """
-
 SAMPLE_RATE = 44100
-# The control rate is the frequency at which modulations are applied
-CONTROL_RATE = 1000
 
 # Small value to avoid log errors.
 EPSILON = 1e-6


### PR DESCRIPTION
Now `sustain_duration` specifies how long the note is held down. See docstring for info.

There's also a one-shot mode, by setting `sustain_duration` to 0. This recreates the envelope behaviour we've been using so far.