### PR TITLE
added convenience import

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -22,7 +22,7 @@ jobs:
           use-isort: true
           extra-pylint-options: ""
           extra-pycodestyle-options: ""
-          extra-flake8-options: "--max-line-length=88 --extend-ignore=E203"
+          extra-flake8-options: "--max-line-length=88 --extend-ignore=E203 --per-file-ignores=__init__.py:F401"
           extra-black-options: ""
           extra-mypy-options: ""
           extra-isort-options: ""

--- a/examples/examples.py
+++ b/examples/examples.py
@@ -15,7 +15,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from ddspdrum.defaults import SAMPLE_RATE
-from ddspdrum.module import ADSR, VCA, Drum, NoiseModule, SineVCO, SquareSawVCO
+from ddspdrum import ADSR, VCA, Drum, NoiseModule, SineVCO, SquareSawVCO
 
 # -
 
@@ -376,9 +376,5 @@ svf = LowPassSVF(cutoff=45, resonance=50)
 kick = svf(signal, cutoff_mod=cutoff_mod, cutoff_mod_amount=150)
 plt.plot(kick)
 ipd.Audio(kick, rate=sample_rate)
-
-
-
-
 
 

--- a/src/ddspdrum/__init__.py
+++ b/src/ddspdrum/__init__.py
@@ -1,1 +1,3 @@
-from ddspdrum.module import ADSR, VCA, Drum, NoiseModule, SineVCO, SquareSawVCO 
+from ddspdrum.module import * 
+__all__ = ['ADSR', 'VCA', 'Drum', 'NoiseModule', 'SineVCO', 'SquareSawVCO']
+

--- a/src/ddspdrum/__init__.py
+++ b/src/ddspdrum/__init__.py
@@ -1,0 +1,1 @@
+from ddspdrum.module import ADSR, VCA, Drum, NoiseModule, SineVCO, SquareSawVCO 

--- a/src/ddspdrum/__init__.py
+++ b/src/ddspdrum/__init__.py
@@ -1,3 +1,2 @@
-from ddspdrum.module import * 
-__all__ = ['ADSR', 'VCA', 'Drum', 'NoiseModule', 'SineVCO', 'SquareSawVCO']
-
+# pylint: disable=unused-import
+from ddspdrum.module import ADSR, VCA, Drum, NoiseModule, SineVCO, SquareSawVCO

--- a/src/ddspdrum/__init__.py
+++ b/src/ddspdrum/__init__.py
@@ -1,2 +1,1 @@
-# pylint: disable=unused-import
 from ddspdrum.module import ADSR, VCA, Drum, NoiseModule, SineVCO, SquareSawVCO


### PR DESCRIPTION
You can take this or leave it. I've been exploring a bit the python package structure.

in essence, this allows for the example.py import:

```from ddspdrum.module import ADSR  # etc...```

to become:

```from ddrpdrum import ADSR # etc...```