### PR TITLE
Rename parameter to modparameter

### DIFF
--- a/examples/examples.py
+++ b/examples/examples.py
@@ -190,7 +190,7 @@ print(my_drum)
 
 # Setting a parameter with a range of [0,1]
 
-my_drum.set_parameter_0to1("pitch_attack", 0.25)
+my_drum.set_modparameter_0to1("pitch_attack", 0.25)
 print(my_drum.parameters['pitch_attack'])
 
 drum_out = my_drum()
@@ -200,11 +200,11 @@ ipd.Audio(drum_out, rate=vca.sample_rate)
 # Setting a parameter with regular range
 
 # +
-my_drum.set_parameter("amp_attack", 1.25)
+my_drum.set_modparameter("amp_attack", 1.25)
 print(my_drum.parameters['amp_attack'])
 
 # Get the value in the range 0 to 1
-print("Value in 0 to 1 range: ", my_drum.get_parameter_0to1('amp_attack'))
+print("Value in 0 to 1 range: ", my_drum.get_modparameter_0to1('amp_attack'))
 # -
 
 drum_out = my_drum()

--- a/examples/examples.py
+++ b/examples/examples.py
@@ -182,7 +182,7 @@ ipd.Audio(drum_out, rate=vca.sample_rate)
 # on. The scale value controls conversion between a range of 0 and 1. Let's look
 # at that more below.
 
-my_drum.parameters
+my_drum.modparameters
 
 # Can also look at parameters by printing the object
 # TODO: this looks a little messy. I know it gets tricky with nested repr. But... just saying.
@@ -191,7 +191,7 @@ print(my_drum)
 # Setting a parameter with a range of [0,1]
 
 my_drum.set_modparameter_0to1("pitch_attack", 0.25)
-print(my_drum.parameters['pitch_attack'])
+print(my_drum.modparameters['pitch_attack'])
 
 drum_out = my_drum()
 stft_plot(drum_out)
@@ -201,7 +201,7 @@ ipd.Audio(drum_out, rate=vca.sample_rate)
 
 # +
 my_drum.set_modparameter("amp_attack", 1.25)
-print(my_drum.parameters['amp_attack'])
+print(my_drum.modparameters['amp_attack'])
 
 # Get the value in the range 0 to 1
 print("Value in 0 to 1 range: ", my_drum.get_modparameter_0to1('amp_attack'))

--- a/src/ddspdrum/modparameter.py
+++ b/src/ddspdrum/modparameter.py
@@ -5,7 +5,7 @@ Parameter Class
 import numpy as np
 
 
-class Parameter:
+class ModParameter:
     """
     Parameter class is a structure for keeping track of parameters
     that have a specific range. Also handles functionality for converting

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -4,7 +4,7 @@ Tests for DDSP Drum Modules
 
 import pytest
 from ddspdrum.module import SynthModule
-from ddspdrum.parameter import Parameter
+from ddspdrum.modparameter import ModParameter
 from ddspdrum.defaults import SAMPLE_RATE
 
 
@@ -16,22 +16,22 @@ class TestSynthModule:
     def test_default_constructor(self):
         module = SynthModule()
         assert module.sample_rate == SAMPLE_RATE
-        assert module.parameters == {}
+        assert module.modparameters == {}
 
     def test_constructor(self):
         sr = 16000
         module = SynthModule(sample_rate=sr)
         assert module.sample_rate == sr
-        assert module.parameters == {}
+        assert module.modparameters == {}
 
     def test_repr(self):
         module = SynthModule()
-        param_1 = Parameter("param_1", 5.0, 0.0, 10.0)
-        param_2 = Parameter("param_2", 0.5, 0.2, 1.0)
-        module.add_parameters([param_1, param_2])
+        param_1 = ModParameter("param_1", 5.0, 0.0, 10.0)
+        param_2 = ModParameter("param_2", 0.5, 0.2, 1.0)
+        module.add_modparameters([param_1, param_2])
 
         expected_str = f"{module.__class__}(sample_rate={SAMPLE_RATE}, "\
-                       f"parameters={repr(module.parameters)})"
+                       f"parameters={repr(module.modparameters)})"
 
         assert repr(module) == expected_str
 
@@ -49,76 +49,76 @@ class TestSynthModule:
 
     def test_add_parameter(self):
         module = SynthModule()
-        parameter_1 = Parameter("param_1", 0.5, 0.0, 1.0)
-        module.add_parameters([parameter_1])
-        assert module.parameters["param_1"] == parameter_1
+        parameter_1 = ModParameter("param_1", 0.5, 0.0, 1.0)
+        module.add_modparameters([parameter_1])
+        assert module.modparameters["param_1"] == parameter_1
 
         # Add a couple more parameters
-        parameter_2 = Parameter("param_2", 0.75, 0.0, 100.0)
-        parameter_3 = Parameter("param_3", 0.11111, 0.1, 0.2)
-        module.add_parameters([parameter_2, parameter_3])
-        assert module.parameters["param_2"] == parameter_2
-        assert module.parameters["param_3"] == parameter_3
+        parameter_2 = ModParameter("param_2", 0.75, 0.0, 100.0)
+        parameter_3 = ModParameter("param_3", 0.11111, 0.1, 0.2)
+        module.add_modparameters([parameter_2, parameter_3])
+        assert module.modparameters["param_2"] == parameter_2
+        assert module.modparameters["param_3"] == parameter_3
 
         # Try add a repeat parameter -- should raise an assertion error
         with pytest.raises(AssertionError):
-            module.add_parameters([parameter_1])
+            module.add_modparameters([parameter_1])
 
     def test_connect_parameter(self):
         sub_module = SynthModule()
-        sub_param_1 = Parameter("param_1", 0.5, 0.0, 1.0, "log")
-        sub_param_2 = Parameter("param_2", 0.5, 0.0, 1.0)
-        sub_module.add_parameters([sub_param_1, sub_param_2])
+        sub_param_1 = ModParameter("param_1", 0.5, 0.0, 1.0, "log")
+        sub_param_2 = ModParameter("param_2", 0.5, 0.0, 1.0)
+        sub_module.add_modparameters([sub_param_1, sub_param_2])
 
         module = SynthModule()
-        module.connect_parameter("connected_param_1", sub_module, "param_1")
-        assert module.parameters["connected_param_1"] == sub_param_1
+        module.connect_modparameter("connected_param_1", sub_module, "param_1")
+        assert module.modparameters["connected_param_1"] == sub_param_1
 
         # Try adding parameter with the same name
         with pytest.raises(ValueError):
-            module.connect_parameter("connected_param_1", sub_module, "param_1")
+            module.connect_modparameter("connected_param_1", sub_module, "param_1")
 
         # Try adding a parameter that doesn't exist
         with pytest.raises(KeyError):
-            module.connect_parameter("connected_param_2", sub_module, "no_param")
+            module.connect_modparameter("connected_param_2", sub_module, "no_param")
 
         # Now add the second param
-        module.connect_parameter("connected_param_2", sub_module, "param_2")
-        assert module.parameters['connected_param_2'] == sub_param_2
+        module.connect_modparameter("connected_param_2", sub_module, "param_2")
+        assert module.modparameters['connected_param_2'] == sub_param_2
 
     def test_get_parameter(self):
         module = SynthModule()
-        param_1 = Parameter("param_1", 0.5, 0.0, 1.0)
-        module.add_parameters([param_1])
+        param_1 = ModParameter("param_1", 0.5, 0.0, 1.0)
+        module.add_modparameters([param_1])
         assert module.get_parameter("param_1") == param_1
 
     def test_get_parameter_0to1(self):
         module = SynthModule()
-        param_1 = Parameter("param_1", 5.0, 0.0, 10.0)
-        module.add_parameters([param_1])
-        assert module.get_parameter_0to1("param_1") == 0.5
+        param_1 = ModParameter("param_1", 5.0, 0.0, 10.0)
+        module.add_modparameters([param_1])
+        assert module.get_modparameter_0to1("param_1") == 0.5
 
     def test_set_parameter(self):
         module = SynthModule()
-        param_1 = Parameter("param_1", 5.0, 0.0, 10.0)
-        module.add_parameters([param_1])
-        assert module.parameters["param_1"].value == 5.0
+        param_1 = ModParameter("param_1", 5.0, 0.0, 10.0)
+        module.add_modparameters([param_1])
+        assert module.modparameters["param_1"].value == 5.0
 
         # Update value
-        module.set_parameter("param_1", 7.5)
-        assert module.parameters["param_1"].value == 7.5
+        module.set_modparameter("param_1", 7.5)
+        assert module.modparameters["param_1"].value == 7.5
 
     def test_set_parameter0to1(self):
         module = SynthModule()
-        param_1 = Parameter("param_1", 5.0, 0.0, 10.0)
-        module.add_parameters([param_1])
-        module.set_parameter_0to1("param_1", 0.25)
-        assert module.parameters["param_1"].value == 2.5
+        param_1 = ModParameter("param_1", 5.0, 0.0, 10.0)
+        module.add_modparameters([param_1])
+        module.set_modparameter_0to1("param_1", 0.25)
+        assert module.modparameters["param_1"].value == 2.5
 
     def test_p(self):
         module = SynthModule()
-        param_1 = Parameter("param_1", 5.0, 0.0, 10.0)
-        param_2 = Parameter("param_2", 0.5, 0.2, 1.0)
-        module.add_parameters([param_1, param_2])
+        param_1 = ModParameter("param_1", 5.0, 0.0, 10.0)
+        param_2 = ModParameter("param_2", 0.5, 0.2, 1.0)
+        module.add_modparameters([param_1, param_2])
         assert module.p("param_1") == 5.0
         assert module.p("param_2") == 0.5


### PR DESCRIPTION
Okay so I'm not sure I love this. However, if TorchSynthModule will inherit from SynthModule and torch.nn.Module, I don't want to break torch. And torch has a special `parameters` class member for each `nn.module`.

Let's also see what happens when we have TorchSynthModules with Torch parameters. That might give us an easy way to address submodule parameters.

The nice thing is this is easy to search and replace, particularly using pycharm, if we want to change this to something nicer later.