### PR TITLE
npyforward instead of __call__

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,9 +8,9 @@ documentation.
 
 * Enforce preconditions on parameter values.
 
-* `SynthModule` should have a `__call__` method. Parameters intrinsic
+* `SynthModule` should have a `npyforward` method. Parameters intrinsic
 to the module should be in `__init__`. Outputs from other modules
-should go in `__call__`.
+should go in `npyforward`.
 
 * Let's standardize on naming conventions for things like `signal`
 or `audio` or whatever.

--- a/examples/examples.py
+++ b/examples/examples.py
@@ -81,7 +81,7 @@ note_on_duration = 0.5
 
 # Envelope test
 adsr = ADSR(a, d, s, r, alpha)
-envelope = adsr(note_on_duration)
+envelope = adsr.npyforward(note_on_duration)
 time_plot(envelope, adsr.sample_rate)
 
 # ### One-Shot Mode
@@ -90,13 +90,13 @@ time_plot(envelope, adsr.sample_rate)
 # envelope to one-shot mode. In this case, the envelope moves through the entire
 # attack, decay, and release.
 
-envelope = adsr(note_on_duration = 0)
+envelope = adsr.npyforward(note_on_duration = 0)
 time_plot(envelope, adsr.sample_rate)
 
 # SineVCO test
 midi_f0 = 12
 sine_vco = SineVCO(midi_f0=midi_f0, mod_depth=50)
-sine_out = sine_vco(envelope, phase=0)
+sine_out = sine_vco.npyforward(envelope, phase=0)
 
 stft_plot(sine_out)
 ipd.Audio(sine_out, rate=sine_vco.sample_rate)
@@ -110,7 +110,7 @@ ipd.Audio(sine_out, rate=sine_vco.sample_rate)
 shape = 0
 midi_f0 = 24
 sqs = SquareSawVCO(shape=shape, midi_f0=midi_f0, mod_depth=6)
-sqs_out = sqs(envelope, phase=0)
+sqs_out = sqs.npyforward(envelope, phase=0)
 # -
 
 stft_plot(sqs_out)
@@ -122,7 +122,7 @@ ipd.Audio(sqs_out, rate=sqs.sample_rate)
 # NoiseModule test.
 
 noiser = NoiseModule(ratio=0.5)
-noisey_out = noiser(sqs_out)
+noisey_out = noiser.npyforward(sqs_out)
 # -
 
 time_plot(noisey_out)
@@ -134,7 +134,7 @@ ipd.Audio(noisey_out, rate=sqs.sample_rate)
 
 # VCA test
 vca = VCA()
-vca_out = vca(envelope, noisey_out)
+vca_out = vca.npyforward(envelope, noisey_out)
 
 time_plot(vca_out)
 stft_plot(vca_out)
@@ -152,7 +152,7 @@ my_drum = Drum(
     note_on_duration=1,
 )
 
-drum_out = my_drum()
+drum_out = my_drum.npyforward()
 
 stft_plot(drum_out)
 
@@ -169,7 +169,7 @@ my_drum = Drum(
     note_on_duration=1,
 )
 
-drum_out = my_drum()
+drum_out = my_drum.npyforward()
 stft_plot(drum_out)
 ipd.Audio(drum_out, rate=vca.sample_rate)
 
@@ -193,7 +193,7 @@ print(my_drum)
 my_drum.set_parameter_0to1("pitch_attack", 0.25)
 print(my_drum.parameters['pitch_attack'])
 
-drum_out = my_drum()
+drum_out = my_drum.npyforward()
 stft_plot(drum_out)
 ipd.Audio(drum_out, rate=vca.sample_rate)
 
@@ -207,7 +207,7 @@ print(my_drum.parameters['amp_attack'])
 print("Value in 0 to 1 range: ", my_drum.get_parameter_0to1('amp_attack'))
 # -
 
-drum_out = my_drum()
+drum_out = my_drum.npyforward()
 stft_plot(drum_out)
 ipd.Audio(drum_out, rate=vca.sample_rate)
 
@@ -247,7 +247,7 @@ plt.show()
 
 # +
 lpf = FIR(cutoff=5000, filter_length=1024)
-filtered_fir = lpf(noise)
+filtered_fir = lpf.npyforward(noise)
 ipd.display(ipd.Audio(filtered_fir, rate=sample_rate))
 
 # Plot Spectrogram
@@ -259,7 +259,7 @@ plt.show()
 
 # +
 lpf = FIR(cutoff=5000, filter_length=32)
-filtered_fir = lpf(noise)
+filtered_fir = lpf.npyforward(noise)
 ipd.display(ipd.Audio(filtered_fir, rate=sample_rate))
 
 # Plot Spectrogram
@@ -271,7 +271,7 @@ plt.show()
 
 # +
 ma_lpf = MovingAverage()
-filtered_ma = ma_lpf(noise)
+filtered_ma = ma_lpf.npyforward(noise)
 ipd.display(ipd.Audio(filtered_ma, rate=sample_rate))
 
 # Plot Spectrogram
@@ -283,7 +283,7 @@ plt.show()
 
 # +
 ma_lpf = MovingAverage(filter_length=64)
-filtered_ma = ma_lpf(noise)
+filtered_ma = ma_lpf.npyforward(noise)
 ipd.display(ipd.Audio(filtered_ma, rate=sample_rate))
 
 # Plot Spectrogram
@@ -298,7 +298,7 @@ plt.show()
 
 # +
 svf = LowPassSVF(cutoff=5000)
-filtered_svf = svf(noise)
+filtered_svf = svf.npyforward(noise)
 ipd.display(ipd.Audio(filtered_svf, rate=sample_rate))
 
 # Plot Spectrogram
@@ -310,7 +310,7 @@ plt.show()
 
 # +
 svf = LowPassSVF(cutoff=5000, resonance=20.0)
-filtered_svf = svf(noise)
+filtered_svf = svf.npyforward(noise)
 ipd.display(ipd.Audio(filtered_svf, rate=sample_rate))
 
 # Plot Spectrogram
@@ -322,7 +322,7 @@ plt.show()
 
 # +
 svf = HighPassSVF(cutoff=5000, resonance=20.0)
-filtered_svf = svf(noise)
+filtered_svf = svf.npyforward(noise)
 ipd.display(ipd.Audio(filtered_svf, rate=sample_rate))
 
 # Plot Spectrogram
@@ -334,7 +334,7 @@ plt.show()
 
 # +
 svf = BandPassSVF(cutoff=5000, resonance=20.0)
-filtered_svf = svf(noise)
+filtered_svf = svf.npyforward(noise)
 ipd.display(ipd.Audio(filtered_svf, rate=sample_rate))
 
 # Plot Spectrogram
@@ -346,7 +346,7 @@ plt.show()
 
 # +
 svf = BandRejectSVF(cutoff=5000)
-filtered_svf = svf(noise)
+filtered_svf = svf.npyforward(noise)
 ipd.display(ipd.Audio(filtered_svf, rate=sample_rate))
 
 # Plot Spectrogram
@@ -373,7 +373,7 @@ plt.plot(cutoff_mod)
 
 # Apply filter and listen to results
 svf = LowPassSVF(cutoff=45, resonance=50)
-kick = svf(signal, cutoff_mod=cutoff_mod, cutoff_mod_amount=150)
+kick = svf.npyforward(signal, cutoff_mod=cutoff_mod, cutoff_mod_amount=150)
 plt.plot(kick)
 ipd.Audio(kick, rate=sample_rate)
 

--- a/src/ddspdrum/module.py
+++ b/src/ddspdrum/module.py
@@ -130,6 +130,9 @@ class SynthModule:
         return self.parameters[parameter_id].value
 
     def __call__(self, *inputs: Any) -> np.ndarray:
+        """
+        Each SynthModule should override this.
+        """
         pass
 
 class ADSR(SynthModule):

--- a/src/ddspdrum/module.py
+++ b/src/ddspdrum/module.py
@@ -135,6 +135,7 @@ class SynthModule:
         """
         pass
 
+
 class ADSR(SynthModule):
     """
     Envelope class for building a control rate ADSR signal

--- a/src/ddspdrum/module.py
+++ b/src/ddspdrum/module.py
@@ -129,9 +129,10 @@ class SynthModule:
         """
         return self.parameters[parameter_id].value
 
-    def __call__(self, *inputs: Any) -> np.ndarray:
+    def npyforward(self, *inputs: Any) -> np.ndarray:
         """
         Each SynthModule should override this.
+        This is the numpy version of the torch.nn.Module.forward command.
         """
         pass
 
@@ -173,7 +174,7 @@ class ADSR(SynthModule):
             ]
         )
 
-    def __call__(self, note_on_duration: float = 0) -> np.ndarray:
+    def npyforward(self, note_on_duration: float = 0) -> np.ndarray:
         """Generate an ADSR envelope.
 
         By default, this envelope reacts as if it was triggered with midi, for
@@ -315,7 +316,7 @@ class VCO(SynthModule):
         # TODO: Make this a parameter too?
         self.phase = phase
 
-    def __call__(self, mod_signal: np.array, phase: float = 0) -> np.ndarray:
+    def npyforward(self, mod_signal: np.array, phase: float = 0) -> np.ndarray:
         """
         Generates audio signal from modulation signal.
 
@@ -431,7 +432,7 @@ class VCA(SynthModule):
     ):
         super().__init__(sample_rate=sample_rate)
 
-    def __call__(self, control_in: np.array, audio_in: np.array) -> np.ndarray:
+    def npyforward(self, control_in: np.array, audio_in: np.array) -> np.ndarray:
         control_in = np.clip(control_in, 0, 1)
         audio_in = np.clip(audio_in, -1, 1)
         audio_in = fix_length(audio_in, len(control_in))
@@ -455,7 +456,7 @@ class NoiseModule(SynthModule):
             ]
         )
 
-    def __call__(self, audio_in: np.ndarray) -> np.ndarray:
+    def npyforward(self, audio_in: np.ndarray) -> np.ndarray:
         noise = self.noise_of_length(audio_in)
         return crossfade(audio_in, noise, self.p("ratio"))
 
@@ -486,7 +487,7 @@ class DummyModule(SynthModule):
         super().__init__(sample_rate=sample_rate)
         self.add_parameters(parameters)
 
-    def __call__(self) -> np.ndarray:
+    def npyforward(self) -> np.ndarray:
         assert False
 
 
@@ -589,7 +590,7 @@ class Drum(Synth):
         # Noise
         self.connect_parameter("noise_ratio", self.noise_module, "ratio")
 
-    def __call__(self) -> np.ndarray:
+    def npyforward(self) -> np.ndarray:
         # The convention for triggering a note event is that it has
         # the same note_on_duration for both ADSRs.
         note_on_duration = self.note_on_duration
@@ -647,7 +648,7 @@ class SVF(SynthModule):
             ]
         )
 
-    def __call__(
+    def npyforward(
         self,
         audio: np.ndarray,
         cutoff_mod: np.ndarray = None,
@@ -840,7 +841,7 @@ class FIR(SynthModule):
             ]
         )
 
-    def __call__(self, audio: np.ndarray) -> np.ndarray:
+    def npyforward(self, audio: np.ndarray) -> np.ndarray:
         """
         Filter audio samples
         TODO: Cutoff frequency modulation, if there is an efficient way to do it
@@ -914,7 +915,7 @@ class MovingAverage(SynthModule):
             ]
         )
 
-    def __call__(self, audio: np.ndarray) -> np.ndarray:
+    def npyforward(self, audio: np.ndarray) -> np.ndarray:
         """
         Filter audio samples
 

--- a/src/ddspdrum/module.py
+++ b/src/ddspdrum/module.py
@@ -594,18 +594,18 @@ class Drum(Synth):
         # The convention for triggering a note event is that it has
         # the same note_on_duration for both ADSRs.
         note_on_duration = self.note_on_duration
-        pitch_envelope = self.pitch_adsr(note_on_duration)
-        amp_envelope = self.amp_adsr(note_on_duration)
+        pitch_envelope = self.pitch_adsr.npyforward(note_on_duration)
+        amp_envelope = self.amp_adsr.npyforward(note_on_duration)
         pitch_envelope = fix_length(pitch_envelope, len(amp_envelope))
 
-        vco_1_out = self.vco_1(pitch_envelope)
-        vco_2_out = self.vco_2(pitch_envelope)
+        vco_1_out = self.vco_1.npyforward(pitch_envelope)
+        vco_2_out = self.vco_2.npyforward(pitch_envelope)
 
         audio_out = crossfade(vco_1_out, vco_2_out, self.p("vco_ratio"))
 
-        audio_out = self.noise_module(audio_out)
+        audio_out = self.noise_module.npyforward(audio_out)
 
-        return self.vca(amp_envelope, audio_out)
+        return self.vca.npyforward(amp_envelope, audio_out)
 
 
 class SVF(SynthModule):

--- a/src/ddspdrum/module.py
+++ b/src/ddspdrum/module.py
@@ -8,7 +8,7 @@ Synth modules.
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Dict, List, Tuple
+from typing import Any, Dict, List, Tuple
 
 import numpy as np
 
@@ -129,6 +129,8 @@ class SynthModule:
         """
         return self.parameters[parameter_id].value
 
+    def __call__(self, *inputs: Any) -> np.ndarray:
+        pass
 
 class ADSR(SynthModule):
     """
@@ -167,7 +169,7 @@ class ADSR(SynthModule):
             ]
         )
 
-    def __call__(self, note_on_duration: float = 0):
+    def __call__(self, note_on_duration: float = 0) -> np.ndarray:
         """Generate an ADSR envelope.
 
         By default, this envelope reacts as if it was triggered with midi, for
@@ -309,7 +311,7 @@ class VCO(SynthModule):
         # TODO: Make this a parameter too?
         self.phase = phase
 
-    def __call__(self, mod_signal: np.array, phase: float = 0) -> np.array:
+    def __call__(self, mod_signal: np.array, phase: float = 0) -> np.ndarray:
         """
         Generates audio signal from modulation signal.
 
@@ -425,7 +427,7 @@ class VCA(SynthModule):
     ):
         super().__init__(sample_rate=sample_rate)
 
-    def __call__(self, control_in: np.array, audio_in: np.array):
+    def __call__(self, control_in: np.array, audio_in: np.array) -> np.ndarray:
         control_in = np.clip(control_in, 0, 1)
         audio_in = np.clip(audio_in, -1, 1)
         audio_in = fix_length(audio_in, len(control_in))
@@ -449,7 +451,7 @@ class NoiseModule(SynthModule):
             ]
         )
 
-    def __call__(self, audio_in: np.ndarray):
+    def __call__(self, audio_in: np.ndarray) -> np.ndarray:
         noise = self.noise_of_length(audio_in)
         return crossfade(audio_in, noise, self.p("ratio"))
 
@@ -480,7 +482,7 @@ class DummyModule(SynthModule):
         super().__init__(sample_rate=sample_rate)
         self.add_parameters(parameters)
 
-    def __call__(self):
+    def __call__(self) -> np.ndarray:
         assert False
 
 
@@ -583,7 +585,7 @@ class Drum(Synth):
         # Noise
         self.connect_parameter("noise_ratio", self.noise_module, "ratio")
 
-    def __call__(self):
+    def __call__(self) -> np.ndarray:
         # The convention for triggering a note event is that it has
         # the same note_on_duration for both ADSRs.
         note_on_duration = self.note_on_duration


### PR DESCRIPTION
All __call__ commands are now npyfoward. I'm not 100% sure but I believe will need this to wrap, as I'm writing the TorchSynthModule.forward.


The nice thing is this is easy to search and replace, particularly using pycharm, if we want to change this to something nicer later.