### PR TITLE
Convert params to floats

### DIFF
--- a/examples/examples.py
+++ b/examples/examples.py
@@ -190,7 +190,7 @@ print(my_drum)
 
 # Setting a parameter with a range of [0,1]
 
-my_drum.set_parameter_0to1("pitch_attack", 0.25)
+my_drum.set_modparameter_0to1("pitch_attack", 0.25)
 print(my_drum.parameters['pitch_attack'])
 
 drum_out = my_drum()
@@ -200,11 +200,11 @@ ipd.Audio(drum_out, rate=vca.sample_rate)
 # Setting a parameter with regular range
 
 # +
-my_drum.set_parameter("amp_attack", 1.25)
+my_drum.set_modparameter("amp_attack", 1.25)
 print(my_drum.parameters['amp_attack'])
 
 # Get the value in the range 0 to 1
-print("Value in 0 to 1 range: ", my_drum.get_parameter_0to1('amp_attack'))
+print("Value in 0 to 1 range: ", my_drum.get_modparameter_0to1('amp_attack'))
 # -
 
 drum_out = my_drum()

--- a/examples/examples.py
+++ b/examples/examples.py
@@ -182,7 +182,7 @@ ipd.Audio(drum_out, rate=vca.sample_rate)
 # on. The scale value controls conversion between a range of 0 and 1. Let's look
 # at that more below.
 
-my_drum.parameters
+my_drum.modparameters
 
 # Can also look at parameters by printing the object
 # TODO: this looks a little messy. I know it gets tricky with nested repr. But... just saying.
@@ -191,7 +191,7 @@ print(my_drum)
 # Setting a parameter with a range of [0,1]
 
 my_drum.set_modparameter_0to1("pitch_attack", 0.25)
-print(my_drum.parameters['pitch_attack'])
+print(my_drum.modparameters['pitch_attack'])
 
 drum_out = my_drum()
 stft_plot(drum_out)
@@ -201,7 +201,7 @@ ipd.Audio(drum_out, rate=vca.sample_rate)
 
 # +
 my_drum.set_modparameter("amp_attack", 1.25)
-print(my_drum.parameters['amp_attack'])
+print(my_drum.modparameters['amp_attack'])
 
 # Get the value in the range 0 to 1
 print("Value in 0 to 1 range: ", my_drum.get_modparameter_0to1('amp_attack'))

--- a/src/ddspdrum/modparameter.py
+++ b/src/ddspdrum/modparameter.py
@@ -5,7 +5,7 @@ Parameter Class
 import numpy as np
 
 
-class Parameter:
+class ModParameter:
     """
     Parameter class is a structure for keeping track of parameters
     that have a specific range. Also handles functionality for converting

--- a/src/ddspdrum/module.py
+++ b/src/ddspdrum/module.py
@@ -24,9 +24,7 @@ class SynthModule:
     WARNING: For now, SynthModules should be atomic and not contain other SynthModules.
     """
 
-    def __init__(
-        self, sample_rate: int = SAMPLE_RATE
-    ):
+    def __init__(self, sample_rate: int = SAMPLE_RATE):
         """
         NOTE:
         __init__ should only set parameters.
@@ -142,7 +140,7 @@ class ADSR(SynthModule):
         s: float = 0.5,
         r: float = 0.5,
         alpha: float = 3.0,
-        sample_rate: int = SAMPLE_RATE
+        sample_rate: int = SAMPLE_RATE,
     ):
         """
         Parameters
@@ -228,9 +226,7 @@ class ADSR(SynthModule):
 
         """
 
-        t = np.linspace(
-            0, duration, self.seconds_to_samples(duration), endpoint=False
-        )
+        t = np.linspace(0, duration, self.seconds_to_samples(duration), endpoint=False)
         return (t / duration) ** self.p("alpha")
 
     @property
@@ -257,7 +253,7 @@ class ADSR(SynthModule):
             out_ = out_[:num_samples]
         elif num_samples > len(out_):
             hold_samples = num_samples - len(out_)
-            out_ = np.pad(out_, [0, hold_samples], mode='edge')
+            out_ = np.pad(out_, [0, hold_samples], mode="edge")
         return out_
 
     def note_off(self, last_val):
@@ -297,7 +293,7 @@ class VCO(SynthModule):
         midi_f0: float = 10.0,
         mod_depth: float = 50.0,
         phase: float = 0.0,
-        sample_rate: int = SAMPLE_RATE
+        sample_rate: int = SAMPLE_RATE,
     ):
         super().__init__(sample_rate=sample_rate)
         self.add_modparameters(
@@ -365,7 +361,9 @@ class SineVCO(VCO):
     Built off the VCO base class, it simply implements a cosine function as oscillator.
     """
 
-    def __init__(self, midi_f0: float = 10.0, mod_depth: float = 50.0, phase: float = 0.0):
+    def __init__(
+        self, midi_f0: float = 10.0, mod_depth: float = 50.0, phase: float = 0.0
+    ):
         super().__init__(midi_f0=midi_f0, mod_depth=mod_depth, phase=phase)
 
     def oscillator(self, argument):
@@ -420,9 +418,7 @@ class VCA(SynthModule):
     Voltage controlled amplifier.
     """
 
-    def __init__(
-        self, sample_rate: int = SAMPLE_RATE
-    ):
+    def __init__(self, sample_rate: int = SAMPLE_RATE):
         super().__init__(sample_rate=sample_rate)
 
     def __call__(self, control_in: np.array, audio_in: np.array):
@@ -437,11 +433,7 @@ class NoiseModule(SynthModule):
     Adds noise.
     """
 
-    def __init__(
-        self,
-        ratio: float = 0.25,
-        sample_rate: int = SAMPLE_RATE
-    ):
+    def __init__(self, ratio: float = 0.25, sample_rate: int = SAMPLE_RATE):
         super().__init__(sample_rate=sample_rate)
         self.add_modparameters(
             [
@@ -465,11 +457,7 @@ class DummyModule(SynthModule):
     without nesting SynthModules and without forcing Synth to be a SynthModule.
     """
 
-    def __init__(
-        self,
-        parameters: List[ModParameter],
-        sample_rate: int = SAMPLE_RATE
-    ):
+    def __init__(self, parameters: List[ModParameter], sample_rate: int = SAMPLE_RATE):
         """
         Parameters
         ----------
@@ -629,14 +617,16 @@ class SVF(SynthModule):
         cutoff: float = 1000.0,
         resonance: float = 0.707,
         self_oscillate: bool = False,
-        sample_rate: int = SAMPLE_RATE
+        sample_rate: int = SAMPLE_RATE,
     ):
         super().__init__(sample_rate=sample_rate)
         self.mode = mode
         self.self_oscillate = self_oscillate
         self.add_modparameters(
             [
-                ModParameter("cutoff", cutoff, 5.0, self.sample_rate / 2.0, curve="log"),
+                ModParameter(
+                    "cutoff", cutoff, 5.0, self.sample_rate / 2.0, curve="log"
+                ),
                 ModParameter("resonance", resonance, 0.5, 1000.0, curve="log"),
             ]
         )
@@ -730,7 +720,7 @@ class LowPassSVF(SVF):
         cutoff: float = 1000.0,
         resonance: float = 0.707,
         self_oscillate: bool = False,
-        sample_rate: int = SAMPLE_RATE
+        sample_rate: int = SAMPLE_RATE,
     ):
         super().__init__(
             mode="LPF",
@@ -751,7 +741,7 @@ class HighPassSVF(SVF):
         cutoff: float = 1000.0,
         resonance: float = 0.707,
         self_oscillate: bool = False,
-        sample_rate: int = SAMPLE_RATE
+        sample_rate: int = SAMPLE_RATE,
     ):
         super().__init__(
             mode="HPF",
@@ -772,7 +762,7 @@ class BandPassSVF(SVF):
         cutoff: float = 1000.0,
         resonance: float = 0.707,
         self_oscillate: bool = False,
-        sample_rate: int = SAMPLE_RATE
+        sample_rate: int = SAMPLE_RATE,
     ):
         super().__init__(
             mode="BPF",
@@ -793,7 +783,7 @@ class BandRejectSVF(SVF):
         cutoff: float = 1000.0,
         resonance: float = 0.707,
         self_oscillate: bool = False,
-        sample_rate: int = SAMPLE_RATE
+        sample_rate: int = SAMPLE_RATE,
     ):
         super().__init__(
             mode="BSF",
@@ -824,7 +814,7 @@ class FIR(SynthModule):
         self,
         cutoff: float = 1000.0,
         filter_length: int = 512,
-        sample_rate: int = SAMPLE_RATE
+        sample_rate: int = SAMPLE_RATE,
     ):
         super().__init__(sample_rate=sample_rate)
         self.add_modparameters(
@@ -896,11 +886,7 @@ class MovingAverage(SynthModule):
     sample_rate (int)   :   Sampling rate to run processing at.
     """
 
-    def __init__(
-        self,
-        filter_length: int = 32,
-        sample_rate: int = SAMPLE_RATE
-    ):
+    def __init__(self, filter_length: int = 32, sample_rate: int = SAMPLE_RATE):
         super().__init__(sample_rate=sample_rate)
         self.add_modparameters(
             [

--- a/src/ddspdrum/module.py
+++ b/src/ddspdrum/module.py
@@ -159,11 +159,11 @@ class ADSR(SynthModule):
         super().__init__(sample_rate=sample_rate)
         self.add_modparameters(
             [
-                ModParameter("attack", a, 0, 20, curve="log"),
-                ModParameter("decay", d, 0, 20, curve="log"),
-                ModParameter("sustain", s, 0, 1),
-                ModParameter("release", r, 0, 20, curve="log"),
-                ModParameter("alpha", alpha, 0, 10),
+                ModParameter("attack", a, 0.0, 20.0, curve="log"),
+                ModParameter("decay", d, 0.0, 20.0, curve="log"),
+                ModParameter("sustain", s, 0.0, 1.0),
+                ModParameter("release", r, 0.0, 20.0, curve="log"),
+                ModParameter("alpha", alpha, 0.0, 10.0),
             ]
         )
 
@@ -294,22 +294,22 @@ class VCO(SynthModule):
 
     def __init__(
         self,
-        midi_f0: float = 10,
-        mod_depth: float = 50,
-        phase: float = 0,
+        midi_f0: float = 10.0,
+        mod_depth: float = 50.0,
+        phase: float = 0.0,
         sample_rate: int = SAMPLE_RATE
     ):
         super().__init__(sample_rate=sample_rate)
         self.add_modparameters(
             [
-                ModParameter("pitch", midi_f0, 0, 127),
-                ModParameter("mod_depth", mod_depth, 0, 127),
+                ModParameter("pitch", midi_f0, 0.0, 127.0),
+                ModParameter("mod_depth", mod_depth, 0.0, 127.0),
             ]
         )
         # TODO: Make this a parameter too?
         self.phase = phase
 
-    def __call__(self, mod_signal: np.array, phase: float = 0) -> np.array:
+    def __call__(self, mod_signal: np.array, phase: float = 0.0) -> np.array:
         """
         Generates audio signal from modulation signal.
 
@@ -365,7 +365,7 @@ class SineVCO(VCO):
     Built off the VCO base class, it simply implements a cosine function as oscillator.
     """
 
-    def __init__(self, midi_f0: float = 10, mod_depth: float = 50, phase: float = 0):
+    def __init__(self, midi_f0: float = 10.0, mod_depth: float = 50.0, phase: float = 0.0):
         super().__init__(midi_f0=midi_f0, mod_depth=mod_depth, phase=phase)
 
     def oscillator(self, argument):
@@ -385,15 +385,15 @@ class SquareSawVCO(VCO):
 
     def __init__(
         self,
-        shape: float = 0,
-        midi_f0: float = 10,
-        mod_depth: float = 50,
-        phase: float = 0,
+        shape: float = 0.0,
+        midi_f0: float = 10.0,
+        mod_depth: float = 50.0,
+        phase: float = 0.0,
     ):
         super().__init__(midi_f0=midi_f0, mod_depth=mod_depth, phase=phase)
         self.add_modparameters(
             [
-                ModParameter("shape", shape, 0, 1),
+                ModParameter("shape", shape, 0.0, 1.0),
             ]
         )
 
@@ -445,7 +445,7 @@ class NoiseModule(SynthModule):
         super().__init__(sample_rate=sample_rate)
         self.add_modparameters(
             [
-                ModParameter("ratio", ratio, 0, 1),
+                ModParameter("ratio", ratio, 0.0, 1.0),
             ]
         )
 
@@ -626,7 +626,7 @@ class SVF(SynthModule):
     def __init__(
         self,
         mode: str,
-        cutoff: float = 1000,
+        cutoff: float = 1000.0,
         resonance: float = 0.707,
         self_oscillate: bool = False,
         sample_rate: int = SAMPLE_RATE
@@ -636,8 +636,8 @@ class SVF(SynthModule):
         self.self_oscillate = self_oscillate
         self.add_modparameters(
             [
-                ModParameter("cutoff", cutoff, 5, self.sample_rate / 2.0, curve="log"),
-                ModParameter("resonance", resonance, 0.5, 1000, curve="log"),
+                ModParameter("cutoff", cutoff, 5.0, self.sample_rate / 2.0, curve="log"),
+                ModParameter("resonance", resonance, 0.5, 1000.0, curve="log"),
             ]
         )
 
@@ -727,7 +727,7 @@ class LowPassSVF(SVF):
 
     def __init__(
         self,
-        cutoff: float = 1000,
+        cutoff: float = 1000.0,
         resonance: float = 0.707,
         self_oscillate: bool = False,
         sample_rate: int = SAMPLE_RATE
@@ -748,7 +748,7 @@ class HighPassSVF(SVF):
 
     def __init__(
         self,
-        cutoff: float = 1000,
+        cutoff: float = 1000.0,
         resonance: float = 0.707,
         self_oscillate: bool = False,
         sample_rate: int = SAMPLE_RATE
@@ -769,7 +769,7 @@ class BandPassSVF(SVF):
 
     def __init__(
         self,
-        cutoff: float = 1000,
+        cutoff: float = 1000.0,
         resonance: float = 0.707,
         self_oscillate: bool = False,
         sample_rate: int = SAMPLE_RATE
@@ -790,7 +790,7 @@ class BandRejectSVF(SVF):
 
     def __init__(
         self,
-        cutoff: float = 1000,
+        cutoff: float = 1000.0,
         resonance: float = 0.707,
         self_oscillate: bool = False,
         sample_rate: int = SAMPLE_RATE
@@ -822,15 +822,15 @@ class FIR(SynthModule):
 
     def __init__(
         self,
-        cutoff: float = 1000,
+        cutoff: float = 1000.0,
         filter_length: int = 512,
         sample_rate: int = SAMPLE_RATE
     ):
         super().__init__(sample_rate=sample_rate)
         self.add_modparameters(
             [
-                ModParameter("cutoff", cutoff, 5, sample_rate / 2.0, curve="log"),
-                ModParameter("length", filter_length, 4, 4096),
+                ModParameter("cutoff", cutoff, 5.0, sample_rate / 2.0, curve="log"),
+                ModParameter("length", filter_length, 4.0, 4096.0),
             ]
         )
 
@@ -904,7 +904,7 @@ class MovingAverage(SynthModule):
         super().__init__(sample_rate=sample_rate)
         self.add_modparameters(
             [
-                ModParameter("length", filter_length, 1, 4096),
+                ModParameter("length", filter_length, 1.0, 4096.0),
             ]
         )
 

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -4,7 +4,7 @@ Tests for DDSP Drum Modules
 
 import pytest
 from ddspdrum.module import SynthModule
-from ddspdrum.parameter import Parameter
+from ddspdrum.modparameter import ModParameter
 from ddspdrum.defaults import SAMPLE_RATE
 
 
@@ -16,22 +16,22 @@ class TestSynthModule:
     def test_default_constructor(self):
         module = SynthModule()
         assert module.sample_rate == SAMPLE_RATE
-        assert module.parameters == {}
+        assert module.modparameters == {}
 
     def test_constructor(self):
         sr = 16000
         module = SynthModule(sample_rate=sr)
         assert module.sample_rate == sr
-        assert module.parameters == {}
+        assert module.modparameters == {}
 
     def test_repr(self):
         module = SynthModule()
-        param_1 = Parameter("param_1", 5.0, 0.0, 10.0)
-        param_2 = Parameter("param_2", 0.5, 0.2, 1.0)
-        module.add_parameters([param_1, param_2])
+        param_1 = ModParameter("param_1", 5.0, 0.0, 10.0)
+        param_2 = ModParameter("param_2", 0.5, 0.2, 1.0)
+        module.add_modparameters([param_1, param_2])
 
         expected_str = f"{module.__class__}(sample_rate={SAMPLE_RATE}, "\
-                       f"parameters={repr(module.parameters)})"
+                       f"parameters={repr(module.modparameters)})"
 
         assert repr(module) == expected_str
 
@@ -49,76 +49,76 @@ class TestSynthModule:
 
     def test_add_parameter(self):
         module = SynthModule()
-        parameter_1 = Parameter("param_1", 0.5, 0.0, 1.0)
-        module.add_parameters([parameter_1])
-        assert module.parameters["param_1"] == parameter_1
+        parameter_1 = ModParameter("param_1", 0.5, 0.0, 1.0)
+        module.add_modparameters([parameter_1])
+        assert module.modparameters["param_1"] == parameter_1
 
         # Add a couple more parameters
-        parameter_2 = Parameter("param_2", 0.75, 0.0, 100.0)
-        parameter_3 = Parameter("param_3", 0.11111, 0.1, 0.2)
-        module.add_parameters([parameter_2, parameter_3])
-        assert module.parameters["param_2"] == parameter_2
-        assert module.parameters["param_3"] == parameter_3
+        parameter_2 = ModParameter("param_2", 0.75, 0.0, 100.0)
+        parameter_3 = ModParameter("param_3", 0.11111, 0.1, 0.2)
+        module.add_modparameters([parameter_2, parameter_3])
+        assert module.modparameters["param_2"] == parameter_2
+        assert module.modparameters["param_3"] == parameter_3
 
         # Try add a repeat parameter -- should raise an assertion error
         with pytest.raises(AssertionError):
-            module.add_parameters([parameter_1])
+            module.add_modparameters([parameter_1])
 
     def test_connect_parameter(self):
         sub_module = SynthModule()
-        sub_param_1 = Parameter("param_1", 0.5, 0.0, 1.0, "log")
-        sub_param_2 = Parameter("param_2", 0.5, 0.0, 1.0)
-        sub_module.add_parameters([sub_param_1, sub_param_2])
+        sub_param_1 = ModParameter("param_1", 0.5, 0.0, 1.0, "log")
+        sub_param_2 = ModParameter("param_2", 0.5, 0.0, 1.0)
+        sub_module.add_modparameters([sub_param_1, sub_param_2])
 
         module = SynthModule()
-        module.connect_parameter("connected_param_1", sub_module, "param_1")
-        assert module.parameters["connected_param_1"] == sub_param_1
+        module.connect_modparameter("connected_param_1", sub_module, "param_1")
+        assert module.modparameters["connected_param_1"] == sub_param_1
 
         # Try adding parameter with the same name
         with pytest.raises(ValueError):
-            module.connect_parameter("connected_param_1", sub_module, "param_1")
+            module.connect_modparameter("connected_param_1", sub_module, "param_1")
 
         # Try adding a parameter that doesn't exist
         with pytest.raises(KeyError):
-            module.connect_parameter("connected_param_2", sub_module, "no_param")
+            module.connect_modparameter("connected_param_2", sub_module, "no_param")
 
         # Now add the second param
-        module.connect_parameter("connected_param_2", sub_module, "param_2")
-        assert module.parameters['connected_param_2'] == sub_param_2
+        module.connect_modparameter("connected_param_2", sub_module, "param_2")
+        assert module.modparameters['connected_param_2'] == sub_param_2
 
     def test_get_parameter(self):
         module = SynthModule()
-        param_1 = Parameter("param_1", 0.5, 0.0, 1.0)
-        module.add_parameters([param_1])
+        param_1 = ModParameter("param_1", 0.5, 0.0, 1.0)
+        module.add_modparameters([param_1])
         assert module.get_parameter("param_1") == param_1
 
     def test_get_parameter_0to1(self):
         module = SynthModule()
-        param_1 = Parameter("param_1", 5.0, 0.0, 10.0)
-        module.add_parameters([param_1])
-        assert module.get_parameter_0to1("param_1") == 0.5
+        param_1 = ModParameter("param_1", 5.0, 0.0, 10.0)
+        module.add_modparameters([param_1])
+        assert module.get_modparameter_0to1("param_1") == 0.5
 
     def test_set_parameter(self):
         module = SynthModule()
-        param_1 = Parameter("param_1", 5.0, 0.0, 10.0)
-        module.add_parameters([param_1])
-        assert module.parameters["param_1"].value == 5.0
+        param_1 = ModParameter("param_1", 5.0, 0.0, 10.0)
+        module.add_modparameters([param_1])
+        assert module.modparameters["param_1"].value == 5.0
 
         # Update value
-        module.set_parameter("param_1", 7.5)
-        assert module.parameters["param_1"].value == 7.5
+        module.set_modparameter("param_1", 7.5)
+        assert module.modparameters["param_1"].value == 7.5
 
     def test_set_parameter0to1(self):
         module = SynthModule()
-        param_1 = Parameter("param_1", 5.0, 0.0, 10.0)
-        module.add_parameters([param_1])
-        module.set_parameter_0to1("param_1", 0.25)
-        assert module.parameters["param_1"].value == 2.5
+        param_1 = ModParameter("param_1", 5.0, 0.0, 10.0)
+        module.add_modparameters([param_1])
+        module.set_modparameter_0to1("param_1", 0.25)
+        assert module.modparameters["param_1"].value == 2.5
 
     def test_p(self):
         module = SynthModule()
-        param_1 = Parameter("param_1", 5.0, 0.0, 10.0)
-        param_2 = Parameter("param_2", 0.5, 0.2, 1.0)
-        module.add_parameters([param_1, param_2])
+        param_1 = ModParameter("param_1", 5.0, 0.0, 10.0)
+        param_2 = ModParameter("param_2", 0.5, 0.2, 1.0)
+        module.add_modparameters([param_1, param_2])
         assert module.p("param_1") == 5.0
         assert module.p("param_2") == 0.5


### PR DESCRIPTION
Builds on #33 

We don't want things that are floats actually to be ints. This can trip up pytorch.