### PR TITLE
linspace func in torchutil w/ endpoint option

### DIFF
--- a/src/ddspdrum/torchmodule.py
+++ b/src/ddspdrum/torchmodule.py
@@ -12,7 +12,7 @@ import torch.tensor as T
 
 from ddspdrum.defaults import SAMPLE_RATE
 from ddspdrum.modparameter import ModParameter
-from ddspdrum.torchutil import midi_to_hz, reverse_signal
+from ddspdrum.torchutil import midi_to_hz, reverse_signal, linspace
 
 torch.pi = torch.acos(torch.zeros(1)).item() * 2  # which is 3.1415927410125732
 
@@ -253,9 +253,7 @@ class TorchADSR(TorchSynthModule):
         """
 
         assert duration.ndim == 0
-        # BUG: We originally used endpoint=False,
-        # which torch.linspace doesn't support :(
-        t = torch.linspace(0, duration.item(), self.seconds_to_samples(duration))
+        t = linspace(0, duration.item(), self.seconds_to_samples(duration))
         return (t / duration) ** self.p("alpha")
 
     @property
@@ -324,7 +322,7 @@ class TorchVCO(TorchSynthModule):
     --------
 
     >>> vco = VCO(midi_f0=69.0, mod_depth=24.0)
-    >>> two_8ve_chirp = vco(torch.linspace(0, 1, 1000, endpoint=False))
+    >>> two_8ve_chirp = vco(linspace(0, 1, 1000, endpoint=False))
     """
 
     def __init__(

--- a/src/ddspdrum/torchmodule.py
+++ b/src/ddspdrum/torchmodule.py
@@ -12,7 +12,7 @@ import torch.tensor as T
 
 from ddspdrum.defaults import SAMPLE_RATE
 from ddspdrum.modparameter import ModParameter
-from ddspdrum.torchutil import midi_to_hz, reverse_signal, linspace
+from ddspdrum.torchutil import linspace, midi_to_hz, reverse_signal
 
 torch.pi = torch.acos(torch.zeros(1)).item() * 2  # which is 3.1415927410125732
 

--- a/src/ddspdrum/torchutil.py
+++ b/src/ddspdrum/torchutil.py
@@ -81,7 +81,7 @@ def linspace(start: T, stop: T, num: T, endpoint: T = False) -> T:
     Wrapper for torch.linspace that allows to count to `stop` non-inclusive.
     """
     # Need to use `==` rather than `is` for correct behaviour w/ tensors.
-    if endpoint == False: # noqa E712
+    if endpoint == False: # noqa: E712
         temp = stop - start
         stop = stop - (temp / num)
 

--- a/src/ddspdrum/torchutil.py
+++ b/src/ddspdrum/torchutil.py
@@ -81,7 +81,7 @@ def linspace(start: T, stop: T, num: T, endpoint: T = False) -> T:
     Wrapper for torch.linspace that allows to count to `stop` non-inclusive.
     """
     # Need to use `==` rather than `is` for correct behaviour w/ tensors.
-    if endpoint == False: # noqa: E712
+    if endpoint == False:  # noqa: E712
         temp = stop - start
         stop = stop - (temp / num)
 

--- a/src/ddspdrum/torchutil.py
+++ b/src/ddspdrum/torchutil.py
@@ -81,7 +81,7 @@ def linspace(start: T, stop: T, num: T, endpoint: T = False) -> T:
     Wrapper for torch.linspace that allows to count to `stop` non-inclusive.
     """
     # Need to use `==` rather than `is` for correct behaviour w/ tensors.
-    if endpoint == False:
+    if endpoint == False: # noqa E712
         temp = stop - start
         stop = stop - (temp / num)
 

--- a/src/ddspdrum/torchutil.py
+++ b/src/ddspdrum/torchutil.py
@@ -76,20 +76,18 @@ def crossfade(in_1: T, in_2: T, ratio: T) -> T:
     return EQ_POW * (torch.sqrt(1 - ratio) * in_1 + torch.sqrt(ratio) * in_2)
 
 
-def linspace(
-        start: float, stop: float, num_steps: int, endpoint: bool = False
-) -> T:
+def linspace(start: T, stop: T, num: T, endpoint: T = False) -> T:
     """
     Wrapper for torch.linspace that allows to count to `stop` non-inclusive.
     """
-    if endpoint is False:
+    # Need to use `==` rather than `is` for correct behaviour w/ tensors.
+    if endpoint == False:
         temp = stop - start
-        stop = stop - (temp / num_steps)
+        stop = stop - (temp / num)
 
-    return torch.linspace(start, stop, num_steps)
- 
- 
+    return torch.linspace(start, stop, num)
+
+
 def reverse_signal(signal: T) -> T:
     assert signal.ndim == 1
     return torch.flip(signal, (0,))
-

--- a/src/ddspdrum/torchutil.py
+++ b/src/ddspdrum/torchutil.py
@@ -74,3 +74,16 @@ def crossfade(in_1: T, in_2: T, ratio: T) -> T:
     """
     assert 0.0 <= ratio <= 1.0
     return EQ_POW * (torch.sqrt(1 - ratio) * in_1 + torch.sqrt(ratio) * in_2)
+
+
+def linspace(
+        start: float, stop: float, num_steps: int, endpoint: bool = False
+) -> T:
+    """
+    Wrapper for torch.linspace that allows to count to `stop` non-inclusive.
+    """
+    if endpoint is False:
+        temp = stop - start
+        stop = stop - (temp / num_steps)
+
+    return torch.linspace(start, stop, num_steps)

--- a/tests/test_torchutil.py
+++ b/tests/test_torchutil.py
@@ -37,6 +37,8 @@ class TestTorchUtil:
                     params[name] = np.random.rand(512)
                 elif ty == "int":
                     params[name] = random.randint(0, 1000)
+                elif ty == "bool":
+                    params[name] = random.choice([True, False])
                 else:
                     assert False
 
@@ -107,4 +109,16 @@ class TestTorchUtil:
             numpyutil.crossfade,
             torchutil.crossfade,
             {"in_1": "signal", "in_2": "signal", "ratio": "pr"},
+        )
+
+    def test_linspace(self):
+        self._compare_values(
+            np.linspace,
+            torchutil.linspace,
+            {
+                "start": "float",
+                "stop": "float",
+                "num": "int",
+                "endpoint": "bool"
+            },
         )


### PR DESCRIPTION
Pretty straightforward. Allows to keep the `np.linspace` behaviour we've been using and keeps the math nice. The only issue is the choice of function name. Currently it's `linspace` straight up.

`linspace_with_option_endpoint` is clear, but long. Another choice is `my_linspace` or something like that.