### PR TITLE
fixed buffer_size for renders

### DIFF
--- a/examples/examples.py
+++ b/examples/examples.py
@@ -390,10 +390,6 @@ kick = svf.npyforward(signal, cutoff_mod=cutoff_mod, cutoff_mod_amount=150)
 plt.plot(kick)
 ipd.Audio(kick, rate=sample_rate)
 
-
-
-
-
 # ## Torch examples
 
 
@@ -446,7 +442,6 @@ err.backward(retain_graph=True)
 for p in adsr.torchparameters:
     print(f"{p} grad1={adsr.torchparameters[p].grad.item()} grad2={adsr2.torchparameters[p].grad.item()}")
 
-# +
 """
 optimizer = torch.optim.SGD(list(adsr.parameters()) + list(adsr2.parameters()), lr=0.01, momentum=0.9)
 
@@ -464,10 +459,6 @@ for i in range(10):
     err.backward()
     optimizer.step()
 """
-# -
-
-
-
 from ddspdrum.torchmodule import TorchSineVCO
 
 # SineVCO vs SineVCO with higher midi_f0

--- a/src/ddspdrum/defaults.py
+++ b/src/ddspdrum/defaults.py
@@ -3,6 +3,9 @@ Default parameters
 """
 SAMPLE_RATE = 44100
 
+# Number of samples for fixed length synthesis.
+BUFFER_SIZE = 88200
+
 # Small value to avoid log errors.
 EPSILON = 1e-6
 

--- a/src/ddspdrum/module.py
+++ b/src/ddspdrum/module.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, List, Tuple
 
 import numpy as np
 
-from ddspdrum.defaults import SAMPLE_RATE, BUFFER_SIZE
+from ddspdrum.defaults import BUFFER_SIZE, SAMPLE_RATE
 from ddspdrum.modparameter import ModParameter
 from ddspdrum.numpyutil import crossfade, fix_length, midi_to_hz
 

--- a/src/ddspdrum/torchmodule.py
+++ b/src/ddspdrum/torchmodule.py
@@ -10,7 +10,7 @@ import torch
 import torch.nn as nn
 import torch.tensor as T
 
-from ddspdrum.defaults import SAMPLE_RATE, BUFFER_SIZE
+from ddspdrum.defaults import BUFFER_SIZE, SAMPLE_RATE
 from ddspdrum.modparameter import ModParameter
 from ddspdrum.torchutil import fix_length, midi_to_hz, reverse_signal
 


### PR DESCRIPTION
Introducing `buffer_size`, which is also a global default `BUFFER_SIZE`.

Now `SynthModule` and `TorchSynthModule` have this property, and a method `to_buffer_size()`. I've placed this at the return for every foward/call:

```
def forward # or npyforward...
  # ...
  out_ = # previous output
  return self.to_buffer_size(out_)
```

There might be a cleaner way of doing this, like making a "pre-forward" method, and then having "forward" always be:
```return self.to_buffer_size(self.pre_forward)```
or some such thing, but that seems confusing and over-engineered.

I fixed up all of `module.py`, and adapted all of `torchmodule.py` that currently exists.

Lmk.