### PR TITLE
fixed 0-length linspace bug

### DIFF
--- a/src/ddspdrum/torchutil.py
+++ b/src/ddspdrum/torchutil.py
@@ -80,8 +80,9 @@ def linspace(start: T, stop: T, num: T, endpoint: T = False) -> T:
     """
     Wrapper for torch.linspace that allows to count to `stop` non-inclusive.
     """
+
     # Need to use `==` rather than `is` for correct behaviour w/ tensors.
-    if endpoint == False:  # noqa: E712
+    if endpoint == False and num != 0:  # noqa: E712
         temp = stop - start
         stop = stop - (temp / num)
 


### PR DESCRIPTION
Avoids divide by zero for 0-length linspaces in torchutil.