### PR TITLE
ADSR remove one-shot

### DIFF
--- a/examples/examples.py
+++ b/examples/examples.py
@@ -88,14 +88,7 @@ envelope = adsr.npyforward(note_on_duration)
 time_plot(envelope, adsr.sample_rate)
 # -
 
-# ### One-Shot Mode
-#
-# Alternately, you can specify a sustain time of "0" which will switch the
-# envelope to one-shot mode. In this case, the envelope moves through the entire
-# attack, decay, and release.
-
-envelope = adsr.npyforward(note_on_duration = 0)
-time_plot(envelope, adsr.sample_rate)
+# ## Oscillators
 
 # SineVCO test
 midi_f0 = 12

--- a/src/ddspdrum/module.py
+++ b/src/ddspdrum/module.py
@@ -219,22 +219,11 @@ class ADSR(SynthModule):
         attack-and-decay (specifically, it will execute the entire attack, and
         only .25 seconds of the decay).
 
-        Alternately, you can specify a `note_on_duration` of "0" which will
-        switch the envelope to one-shot mode. In this case, the envelope moves
-        through the entire attack, decay, and release, with no held "sustain"
-        value.
-
         If this is confusing, don't worry about it. ADSR's do a lot of work
         behind the scenes to make the playing experience feel natural.
 
         """
-
-        assert note_on_duration >= 0
-
-        # If sustain is "0" go to one-shot mode (moves through ADR sections).
-        if note_on_duration == 0:
-            note_on_duration = self.p("attack") + self.p("decay")
-
+        assert note_on_duration > 0
         num_samples = self.seconds_to_samples(note_on_duration)
 
         # Release decays from the last value of the attack-and-decay sections.

--- a/src/ddspdrum/torchmodule.py
+++ b/src/ddspdrum/torchmodule.py
@@ -219,22 +219,11 @@ class TorchADSR(TorchSynthModule):
         attack-and-decay (specifically, it will execute the entire attack, and
         only .25 seconds of the decay).
 
-        Alternately, you can specify a `note_on_duration` of "0" which will
-        switch the envelope to one-shot mode. In this case, the envelope moves
-        through the entire attack, decay, and release, with no held "sustain"
-        value.
-
         If this is confusing, don't worry about it. ADSR's do a lot of work
         behind the scenes to make the playing experience feel natural.
-
         """
 
-        assert note_on_duration >= 0
-
-        # If sustain is "0" go to one-shot mode (moves through ADR sections).
-        if note_on_duration == T(0):
-            note_on_duration = self.p("attack") + self.p("decay")
-
+        assert note_on_duration > 0
         num_samples = self.seconds_to_samples(note_on_duration)
 
         # Release decays from the last value of the attack-and-decay sections.


### PR DESCRIPTION
Removing the one-shot condition re issue #66 -- no separate module for now for one-shot mode since the envelope for that can be created by setting the parameters correctly in the ADSR as it is now. If we feel like we want to add a one-shot module in the future then we can do that.